### PR TITLE
✨ LiquidityPool V2: loss split, pull-based treasury, role separation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,10 @@
       "Bash(~/.foundry/bin/forge test:*)",
       "Bash(forge test:*)",
       "Bash(python3 -c ' *)",
-      "Bash(node -e ' *)"
+      "Bash(node -e ' *)",
+      "Bash(git submodule *)",
+      "Bash(awk '/^[^\\\\/].*\".*[^\\\\x00-\\\\x7F].*\"/' chiliz-tv/test/LiquidityPoolV2Test.t.sol)",
+      "Bash(git add *)"
     ]
   }
 }

--- a/chiliz-tv/DEPLOYMENT_SUMMARY.md
+++ b/chiliz-tv/DEPLOYMENT_SUMMARY.md
@@ -62,6 +62,8 @@ This PR adds comprehensive deployment scripts for all Chiliz-TV smart contracts 
 - Explained in comments and documentation
 - Different from deployer (Foundry limitation)
 
+> **Important — LiquidityPool admin/treasury split (2026-04-22 onwards):** on `LiquidityPool`, the admin key (`DEFAULT_ADMIN_ROLE`) and the `treasury` state variable MUST be distinct addresses. The admin key runs operational setters and upgrades; the treasury Safe is the ONLY address that can rotate treasury (via 2-step `proposeTreasury` / `acceptTreasury`) and pull accrued funds via `withdrawTreasury`. Deploying with a single Safe for both collapses the compartmentalisation. See [docs/treasury.md](docs/treasury.md).
+
 ### UUPS Proxy Pattern Explained
 
 Every deployment script follows the UUPS (Universal Upgradeable Proxy Standard) pattern:
@@ -104,10 +106,10 @@ All scripts follow this streamlined order:
    - Implementation pointers on both factories are **mutable** via `onlyOwner` setters (`setFootballImplementation` / `setBasketballImplementation` / `setImplementation`). They affect **new proxy deployments only** — existing proxies are NOT auto-upgraded and must be upgraded individually (UUPS on betting via `upgradeToAndCall`, UUPS on streaming via `StreamWalletFactory.upgradeWallet`).
 
 2. **Transfer Ownership** (to Safe multisig)
-   - BettingMatchFactory â†’ Safe (controls who gets new matches + implementation pointer)
-   - StreamWalletFactory â†’ Safe (controls per-wallet upgrades)
-   - LiquidityPool → Safe (DEFAULT_ADMIN_ROLE: controls match whitelist, caps, fees, upgrade)
-   - ChilizSwapRouter â†’ Safe (controls treasury, platformFeeBps, registered factories)
+   - BettingMatchFactory → Safe (controls who gets new matches + implementation pointer)
+   - StreamWalletFactory → Safe (controls per-wallet upgrades)
+   - LiquidityPool admin → **Admin key (EOA or dedicated ops multisig — NOT the treasury Safe)**. `DEFAULT_ADMIN_ROLE` controls match whitelist, caps, fees, pause, upgrades. Treasury Safe is passed as a **separate** `treasury_` parameter at `initialize()` and is the only address that can rotate treasury or withdraw accrued funds.
+   - ChilizSwapRouter → Safe (controls treasury, platformFeeBps, registered factories — Ownable, independent of the pool's admin/treasury split)
 
 **Gas Optimization:**
 - First proxy deployment: ~680K gas (factory constructor cost already paid separately — implementations sit on-chain ready to be reused)

--- a/chiliz-tv/README.md
+++ b/chiliz-tv/README.md
@@ -451,9 +451,12 @@ router with the streaming factory.
 | # | Call | Caller (role) | If skipped |
 |---|------|---------------|------------|
 | 1 | `match.setUSDCToken(usdc)` | `ADMIN_ROLE` | `placeBetUSDC` reverts `USDCNotConfigured` |
-| 2 | `pool.authorizeMatch(match)` | `DEFAULT_ADMIN_ROLE` (Safe on pool) | Pool refuses `recordBet` / `payWinner` → reverts `MatchNotAuthorized` |
-| 4 | `match.grantRole(RESOLVER_ROLE, oracle)` | `DEFAULT_ADMIN_ROLE` | `resolveMarket` reverts. **RESOLVER is deliberately NOT granted at init** to separate the resolver key from the admin key. |
-| 5 | `match.grantRole(SWAP_ROUTER_ROLE, ChilizSwapRouter)` | `DEFAULT_ADMIN_ROLE` | Any `placeBetWith*` routed through the swap router reverts |
+| 2 | `match.setLiquidityPool(pool)` | `ADMIN_ROLE` | `placeBetUSDC` reverts `LiquidityPoolNotConfigured` |
+| 3 | `pool.authorizeMatch(match)` | `DEFAULT_ADMIN_ROLE` (admin key on pool — **NOT** the treasury Safe) | Pool refuses `recordBet` / `payWinner` → reverts `MatchNotAuthorized` |
+| 4 | `match.grantRole(RESOLVER_ROLE, oracle)` | `DEFAULT_ADMIN_ROLE` (match admin) | `resolveMarket` reverts. **RESOLVER is deliberately NOT granted at init** to separate the resolver key from the admin key. |
+| 5 | `match.grantRole(SWAP_ROUTER_ROLE, ChilizSwapRouter)` | `DEFAULT_ADMIN_ROLE` (match admin) | Any `placeBetWith*` routed through the swap router reverts |
+| 6 | `match.setMaxAllowedOdds(maxOdds)` *(recommended)* | `ADMIN_ROLE` | Falls back to hardcoded `MAX_ODDS = 100x` (1_000_000). Tighten per-sport to harden against odds-setter fat-fingers. |
+| 7 | `pool.setMaxBetAmount(cap)` *(recommended)* | `DEFAULT_ADMIN_ROLE` (pool admin) | 0 disables. Any single bet larger than this (post-fee netStake) reverts `BetAmountAboveCap`. |
 
 **Swap router ↔ streaming factory (one-time)**
 
@@ -465,8 +468,9 @@ Order matters — the router asserts the factory knows about it:
 **Optional but recommended**
 
 - `ChilizSwapRouter.setMatchFactory(bettingMatchFactory)` — without this, the router will forward USDC to any `bettingMatch` argument, not just factory-registered ones (M-02 hardening).
-- Transfer `DEFAULT_ADMIN_ROLE` on `LiquidityPool`, `BettingMatchFactory`, `StreamWalletFactory`, and `ChilizSwapRouter` to the Safe multisig.
-- Seed the `LiquidityPool` via `deposit(amount, receiver)` (requires USDC approval first).
+- **Role separation on `LiquidityPool` (critical):** the admin key (`DEFAULT_ADMIN_ROLE`) and the `treasury` state variable MUST be distinct addresses. Admin is typically a Safe or ops EOA for operational changes; the treasury is the Safe that pulls accrued funds. Deploying with the same address collapses the compartmentalisation and lets an admin compromise drain accrued treasury. See [docs/treasury.md](docs/treasury.md).
+- Transfer `DEFAULT_ADMIN_ROLE` on `BettingMatchFactory`, `StreamWalletFactory`, and `ChilizSwapRouter` to the Safe multisig (these are singleton admin keys for those contracts — separate from the pool's admin/treasury split).
+- Seed the `LiquidityPool` via `deposit(amount, receiver)` (requires USDC approval first). First deposit is safe against inflation attack (`_decimalsOffset = 6`).
 
 ---
 
@@ -617,24 +621,52 @@ cast send $STREAM_FACTORY \
 ## 6. Security & Access Control
 
 ### 6.1 Betting System
-- **ADMIN_ROLE**: Add markets, control market state (open/suspend/close/cancel)
+
+**Roles on each BettingMatch:**
+- **ADMIN_ROLE**: Add markets, control market state (open/suspend/close/cancel), `setMaxAllowedOdds`, `setUSDCToken`, `setLiquidityPool`
 - **ODDS_SETTER_ROLE**: Update market odds in real-time
 - **RESOLVER_ROLE**: Set final results for markets
 - **PAUSER_ROLE**: Emergency pause/unpause
-- **TREASURY_ROLE**: Fund USDC treasury, emergency USDC withdrawal
 - **SWAP_ROUTER_ROLE**: Allows ChilizSwapRouter to call `placeBetUSDCFor`
 - **Factory Owner**: Can point the factory at a new implementation for FUTURE match deployments via `setFootballImplementation` / `setBasketballImplementation`. Existing proxies are NOT auto-upgraded.
+
+> **Note:** the match contract no longer holds USDC. There is no `TREASURY_ROLE` — all USDC lives in `LiquidityPool`, which has its own admin/treasury separation (see §6.3).
+
+**Upgrade path:**
 - **UUPS**: Each match can be upgraded individually by its own `DEFAULT_ADMIN_ROLE` holder. **`DEFAULT_ADMIN_ROLE` is granted to the `_owner` passed into `createFootballMatch` / `createBasketballMatch`** — set this to a multisig unless you fully trust the key, because a DEFAULT_ADMIN holder can also self-grant `RESOLVER_ROLE` and resolve markets.
 - **RESOLVER_ROLE is NOT auto-granted at init.** You must `grantRole(RESOLVER_ROLE, oracle)` on every new match before any resolution will succeed. This is deliberate — it separates the key that resolves markets from the key that administers them.
+
+**Odds-setter hardening (operational defence):**
+- `BettingMatch.setMaxAllowedOdds(uint32)` — admin-settable per-match soft cap on odds (default 0 = use hardcoded `MAX_ODDS = 100x`). Tighten per sport: a fat-finger that accidentally sets 1000x instead of 10x is blocked at `setMarketOdds`.
+- `LiquidityPool.setMaxBetAmount(uint256)` — pool-wide max per-bet netStake (0 = disabled). Bounds damage per bet regardless of the attacker's capital.
+- Runtime `pause()` on the pool is the emergency kill-switch.
 
 ### 6.2 Streaming System
 - **Streamer (StreamWallet beneficiary)**: Can call `withdrawRevenue()` to drain the wallet's USDC balance.
 - **StreamWalletFactory Owner**: Can create wallets, set fee/treasury/router parameters, and **upgrade each streamer wallet individually** via `upgradeWallet(streamer, newImpl)`. `StreamWallet._authorizeUpgrade` is locked to the factory, so this is the only upgrade path.
 - **No atomic upgrades.** There is no beacon and no `StreamBeaconRegistry`. Upgrading N wallets = N transactions. Put the factory behind a Safe multisig.
 
-### 6.3 Treasury
-- **Safe Multisig**: Receives platform fees from streaming system
-- Controlled by multiple signers for security
+### 6.3 Treasury & LiquidityPool
+
+**Two distinct keys on `LiquidityPool`** — do NOT conflate them:
+
+| Key | On-chain authority | What it can do | What it CANNOT do |
+|---|---|---|---|
+| **Admin key** | `DEFAULT_ADMIN_ROLE` + `PAUSER_ROLE` | Authorize/revoke matches, `setProtocolFeeBps`, `setMaxLiabilityPerMarketBps`, `setMaxLiabilityPerMatchBps`, `setMaxBetAmount`, `setDepositCooldownSeconds`, `pause` / `unpause`, UUPS upgrades | Rotate `treasury`, touch `accruedTreasury`, withdraw USDC |
+| **Treasury Safe** | `treasury` state variable (NOT a role) | `proposeTreasury` / `cancelTreasuryProposal` / `acceptTreasury` / `withdrawTreasury` | Authorize matches, set fees, pause, upgrade |
+
+**Loss split (hardcoded 50/50):** every losing net-stake at settlement splits — half to `accruedTreasury` (pull-claim for the Safe), half compounded into LP NAV.
+
+**Treasury rotation is 2-step:** current Safe calls `proposeTreasury(newSafe)`; the incoming Safe must call `acceptTreasury()` from its own address. Protects against fat-finger rotations — only path for rotation, admin CANNOT rotate.
+
+**Pull, not push:** accrued balance sits as USDC inside the pool. The Safe pulls via `withdrawTreasury(amount)`. The call is bounded by `treasuryWithdrawable() = min(accruedTreasury, USDC.balance − totalLiabilities)` — bettors always have precedence.
+
+**Inflation-attack mitigated:** ctvLP uses OZ 5.x `_decimalsOffset = 6` (12 total decimals). First deposit is safe regardless of size.
+
+**Other treasury-adjacent:**
+- **Streaming platform fees**: forwarded directly to the Safe by `StreamWalletFactory` / `ChilizSwapRouter`. Admin on those factories rotates treasury via their own `setTreasury` (Ownable — unchanged, independent of the pool's 2-step pattern).
+
+See [docs/treasury.md](docs/treasury.md) for the operational runbook and [docs/liquidity-providers.md](docs/liquidity-providers.md) for the LP-facing explainer.
 
 ---
 
@@ -690,4 +722,4 @@ For technical questions or integration support, contact the ChilizTV development
 
 ---
 
-**Last Updated**: 2026-02-20
+**Last Updated**: 2026-04-22 — added LiquidityPool 50/50 loss split, pull-based treasury withdrawal, 2-step treasury rotation, admin/treasury role separation, ERC-4626 inflation mitigation, `maxBetAmount`, `maxAllowedOdds`, utilization views.

--- a/chiliz-tv/docs/liquidity-providers.md
+++ b/chiliz-tv/docs/liquidity-providers.md
@@ -1,0 +1,137 @@
+# ChilizTV — Liquidity Provider Guide
+
+**You (the LP) are the house.** When bettors lose, you earn. When bettors win, your capital pays them. This guide explains precisely how that works, what risks you take, and how to deposit, monitor, and withdraw.
+
+---
+
+## TL;DR
+
+- You deposit **USDC** into the `LiquidityPool` and receive **ctvLP** shares (ERC-4626).
+- Every losing bet sends **50% of the net stake** to LP NAV (auto-compounded into your share price) and the other **50% to a treasury claim**.
+- Every winning bet is paid out from the pool. That payout is funded **only by LP capital** — the treasury's accrued claim is not at risk.
+- Your withdrawal may be temporarily capped by outstanding bet liabilities (see **Free balance & utilization** below).
+
+---
+
+## How yield is generated
+
+1. Bettor stakes USDC on a market at fixed odds set by the backend.
+2. Bettor's stake is split: a small protocol fee goes directly to the treasury, the rest (`netStake`) enters the pool. The pool also reserves `netExposure = netStake × odds / 10000 − netStake` against its free balance to guarantee the payout if the bet wins.
+3. **When the bet loses:**
+   - `netExposure` reservation is released back into free balance.
+   - `netStake` stays in the pool. `50% (TREASURY_SHARE_BPS)` is earmarked as `accruedTreasury`; the remaining 50% is untouched USDC that now belongs to LPs (visible as an increase in `totalAssets()` and therefore in your ctvLP share price).
+4. **When the bet wins:**
+   - Pool pays `payout = netStake × odds / 10000` in USDC to the winner.
+   - The bet's reserved `netExposure` is released.
+   - Net outflow for LP NAV = `payout − netStake = netExposure`. The treasury's accrued claim is NOT touched.
+
+Over many bets with a correctly-priced house edge, losing stakes dominate winning payouts and ctvLP share price trends upward. This yield is **real yield** — there is no token emission, no inflationary subsidy. Every unit of LP NAV comes from actual bet losses.
+
+---
+
+## The treasury asymmetry (read this carefully)
+
+**The treasury's accrued claim is a fixed historical allocation.** When a bet loses, 50% of the net stake is booked to `accruedTreasury` and that figure never decreases except when the treasury actively pulls it via `withdrawTreasury()`. Winning bets do NOT reduce the treasury's claim.
+
+**What this means for you as an LP:**
+
+- You absorb **100% of the downside** from winning-bet payouts.
+- The treasury captures a **fixed, variance-free 50%** of every losing stake.
+- Your risk-adjusted return is lower than if treasury shared drawdowns with you (pari-passu model).
+
+**Worked example** — LP deposits 1000 USDC:
+
+| Event | Pool USDC | accruedTreasury | totalAssets | ctvLP share price |
+|---|---:|---:|---:|---:|
+| LP deposits 1000 | 1000 | 0 | 1000 | 1.00 |
+| Bettors lose 200 net stake | 1200 | 100 | 1100 | 1.10 |
+| Bettor wins: stake 200, payout 1000 | 400 | 100 | 300 | 0.30 |
+
+After the winning bet, LP is down 70% while treasury's 100 claim is intact. If the house edge is priced correctly, over a large sample of bets the losing-bet compounding outpaces winning-bet drawdowns — but day-to-day LP returns are much more volatile than treasury accrual.
+
+---
+
+## Free balance & utilization
+
+Two numbers you should watch:
+
+- **`freeBalance()`** — USDC available right now for LP withdrawals (= `totalAssets()`).
+- **`utilization()`** — `totalLiabilities / totalAssets` in basis points. 7000 = 70% utilization; 10000+ = fully utilized.
+
+When utilization is high, `maxWithdraw(you)` may return less than the nominal value of your shares. This is protective: the pool cannot pay out more than `freeBalance` without risking bet-payout insolvency. When bets settle, free balance replenishes and the cap lifts automatically. Cooldown (`depositCooldownSeconds`) also gates each individual depositor — you cannot deposit and withdraw inside the cooldown window.
+
+**Peak-weekend planning:** if you anticipate needing liquidity during a heavy match day, withdraw ahead of kickoff. Mid-weekend withdrawals may be partially blocked until games settle.
+
+---
+
+## Depositing
+
+```solidity
+USDC.approve(address(liquidityPool), amount);
+liquidityPool.deposit(amount, yourAddress);
+```
+
+You receive ctvLP shares. Share price = `totalAssets() / totalSupply`. Shares are transferable ERC-20s.
+
+**Inflation-attack protection.** The pool uses OpenZeppelin 5.x's `_decimalsOffset = 6`, which makes the classic first-depositor attack uneconomic. You can safely deposit any amount regardless of whether you're the first LP or the hundredth.
+
+---
+
+## Withdrawing
+
+```solidity
+liquidityPool.withdraw(assets, yourAddress, yourAddress);
+// or
+liquidityPool.redeem(shares, yourAddress, yourAddress);
+```
+
+Both respect `maxWithdraw` / `maxRedeem`, which return the minimum of your share-value and the pool's free balance. If you try to pull more than the cap, the transaction reverts cleanly.
+
+Before withdrawing, check:
+- `maxWithdraw(you)` — how much you can pull right now.
+- `utilization()` — pool stress level.
+- Your `lastDepositAt[you] + depositCooldownSeconds` — cooldown expiry.
+
+---
+
+## Risks you are taking
+
+1. **Odds-setter error or compromise.** The backend sets odds off-chain. A bug or compromised key could systematically favor bettors. Mitigations: `maxAllowedOdds` cap per match, `maxBetAmount` pool-wide cap, emergency `pause()`. All three are operational, not eliminating the risk.
+2. **Tail events.** A correlated cluster of winning bets (favorites all hitting on one match day) can rapidly draw down LP NAV. Per-market and per-match caps mitigate this but do not eliminate cross-match correlation.
+3. **Smart-contract risk.** The pool is UUPS-upgradeable. An upgrade bug or admin-key compromise could damage the pool. Upgrades are gated by `DEFAULT_ADMIN_ROLE` which is distinct from the treasury Safe.
+4. **Withdrawal liquidity risk.** During high utilization, you may face temporary withdrawal caps. Plan exits around settlement cycles.
+5. **Treasury asymmetry.** Already covered above — LPs carry all downside; treasury's accrual is protected.
+6. **Pricing model risk.** If the house edge is underpriced (or backend pricing is stale vs. real market), LPs lose expected return. You are implicitly trusting the odds-setter's modelling.
+
+---
+
+## Key contract reads for monitoring
+
+| Call | Meaning |
+|---|---|
+| `totalAssets()` | LP-owned USDC (your share of this = ctvLP % × totalAssets). |
+| `freeBalance()` | USDC available for LP withdrawals right now. |
+| `totalLiabilities()` | USDC reserved for outstanding bet payouts. |
+| `utilization()` | Liabilities / totalAssets in bps. |
+| `accruedTreasury()` | Treasury's pull-claim on the pool (NOT LP capital). |
+| `treasuryWithdrawable()` | How much treasury can pull RIGHT NOW. |
+| `maxWithdraw(you)` | Your current withdraw cap. |
+| `maxRedeem(you)` | Same, in share terms. |
+| `convertToAssets(shares)` | Convert your shares to nominal USDC value. |
+| `lastDepositAt(you)` | Your cooldown anchor timestamp. |
+
+---
+
+## What ChilizTV commits to LPs
+
+- **No emission subsidies.** All yield is real yield from losing bets.
+- **Transparent accounting.** Every bet, settlement, accrual, and withdrawal emits events. Anyone can reconstruct full pool history from logs.
+- **No sudden parameter flips.** Protocol fee, caps, and cooldowns are admin-settable but each change emits a public event. LP-docs updates will flag any material shift.
+- **Separation of powers.** Admin key (operational) and Safe treasury are distinct. Admin cannot touch accrued treasury funds. Treasury cannot upgrade the contract or authorize matches.
+- **Pull-based treasury.** Accrued treasury balance stays inside the pool until the Safe actively withdraws — if the team never pulls, their accrued balance continues to back pool solvency (but does not dilute LP share price).
+
+---
+
+## Contract addresses
+
+See [DEPLOYMENT_SUMMARY.md](../DEPLOYMENT_SUMMARY.md) for current deployed addresses (mainnet + testnet).

--- a/chiliz-tv/docs/payout.md
+++ b/chiliz-tv/docs/payout.md
@@ -17,24 +17,40 @@ The ChilizTV betting system uses a **LiquidityPool-backed payout** architecture.
 
 | Role | Holder | Responsibility |
 |------|--------|----------------|
-| `DEFAULT_ADMIN_ROLE` (pool) | Gnosis Safe | Authorize/revoke matches, set treasury & fees, upgrade pool |
+| `DEFAULT_ADMIN_ROLE` (pool) | **Admin key (EOA or multisig) — NOT the treasury Safe** | Authorize/revoke matches, set fees & caps & cooldown & `maxBetAmount`, upgrade pool |
+| `PAUSER_ROLE` (pool) | Admin key / security team | Emergency pause |
 | `MATCH_ROLE` (pool) | Each BettingMatch proxy | Call `recordBet`, `settleMarket`, `payWinner`, `payRefund` |
 | `ROUTER_ROLE` (pool) | ChilizSwapRouter | Call `recordBet` on behalf of users |
-| `PAUSER_ROLE` (pool) | Safe / security team | Emergency pause |
-| `ADMIN_ROLE` (match) | Match owner | Create markets, manage state |
+| `treasury` (pool state) | **Treasury Safe (multisig)** | `proposeTreasury` / `cancelTreasuryProposal` / `acceptTreasury` / `withdrawTreasury` |
+| `ADMIN_ROLE` (match) | Match owner | Create markets, manage state, `setMaxAllowedOdds` |
 | `RESOLVER_ROLE` (match) | Oracle / admin | Resolve markets with results |
+
+**Role separation is enforced on-chain.** Admin cannot touch `accruedTreasury` or rotate `treasury`. Treasury cannot authorize matches, change fees, or upgrade the pool. Deploy with distinct addresses for `admin_` and `treasury_` in `initialize(...)`. See [treasury.md](treasury.md).
 
 ## NAV Model
 
 ```
-totalAssets()   = USDC.balanceOf(pool) - totalLiabilities
-freeBalance()   = totalAssets()   (unreserved USDC, available for LP withdrawal)
+totalAssets()   = USDC.balanceOf(pool) - totalLiabilities - accruedTreasury
+freeBalance()   = totalAssets()              (LP-withdrawable USDC)
+utilization()   = totalLiabilities × 10_000 / totalAssets()   (bps)
 totalLiabilities = Σ netExposure across all open winning-side positions
+accruedTreasury = Σ 50% of losingNetStake accumulated at settlement (pull-claim)
 ```
 
-When a bet is placed: `USDC in ↑`, `totalLiabilities ↑` → `totalAssets()` unchanged.
-When a winner claims: `USDC out ↓`, `totalLiabilities ↓` → `totalAssets()` drops by `stake` (pool's realised loss).
-When a loser's market settles: `totalLiabilities ↓` → `totalAssets()` rises (pool keeps the stake).
+Claims against the pool's USDC balance, in precedence:
+1. **Winners** — `totalLiabilities` (senior, reserved).
+2. **Treasury** — `accruedTreasury` (pullable by Safe, never absorbs winning-bet losses).
+3. **LPs** — residual, priced into ctvLP shares.
+
+State deltas:
+
+| Event | USDC balance | totalLiabilities | accruedTreasury | totalAssets (LP NAV) |
+|---|---|---|---|---|
+| Bet placed (netStake in, exposure reserved) | +netStake | +netExposure | — | −netExposure +netStake |
+| Winner claims | −payout | −netExposure | — | −netStake (pool's realised loss) |
+| Loser's market settles | — | −losingNetExposure | +losingNetStake × 50% | +losingNetStake × 50% |
+| Refund (cancelled market) | −stake | −netExposure | — | −(netExposure − stake) ≈ 0 |
+| `withdrawTreasury(x)` | −x | — | −x | unchanged |
 
 ## Payout Flow
 
@@ -57,10 +73,12 @@ sequenceDiagram
     Pool-->>Pool: totalLiabilities += netExposure; cap checks pass
     Match-->>User: Bet recorded ✓
 
-    Note over LP,User: Phase 3: Market resolution
+    Note over LP,User: Phase 3: Market resolution (50/50 loss split)
     Match->>Match: resolveMarket(marketId, result)
-    Match->>Pool: settleMarket(match, marketId, losingLiabilityToRelease)
-    Pool-->>Pool: totalLiabilities -= losingLiability (losers' stakes kept by pool)
+    Match->>Pool: settleMarket(match, marketId, losingNetExposure, losingNetStake)
+    Pool-->>Pool: totalLiabilities -= losingNetExposure
+    Pool-->>Pool: accruedTreasury += losingNetStake × 5000 / 10_000 (50% to treasury)
+    Pool-->>Pool: remaining 50% stays in USDC balance → compounds into LP NAV
 
     Note over LP,User: Phase 4: Winner claims
     User->>Match: claim(marketId, betIndex)
@@ -81,6 +99,39 @@ sequenceDiagram
     Match->>Pool: payRefund(match, marketId, user, stake, releasedNetExposure)
     Pool->>User: USDC.safeTransfer(user, stake)
     Pool-->>Pool: totalLiabilities -= releasedNetExposure
+```
+
+### Treasury Withdrawal (pull-based)
+
+```mermaid
+sequenceDiagram
+    participant Safe as Treasury Safe
+    participant Pool as LiquidityPool
+
+    Safe->>Pool: withdrawTreasury(amount)
+    Pool->>Pool: require msg.sender == treasury
+    Pool->>Pool: available = min(accruedTreasury, USDC − totalLiabilities)
+    Pool->>Pool: require amount <= available
+    Pool->>Pool: accruedTreasury -= amount (CEI)
+    Pool->>Safe: USDC.safeTransfer(treasury, amount)
+    Note over Pool: LP NAV unchanged — the claim was already<br/>excluded from totalAssets()
+```
+
+### Treasury Rotation (2-step)
+
+```mermaid
+sequenceDiagram
+    participant A as Safe A (current)
+    participant Pool as LiquidityPool
+    participant B as Safe B (target)
+
+    A->>Pool: proposeTreasury(B)
+    Pool-->>Pool: pendingTreasury = B
+    Note over A,B: Safe A retains full rights until Safe B accepts
+    B->>Pool: acceptTreasury()
+    Pool->>Pool: require msg.sender == pendingTreasury
+    Pool-->>Pool: treasury = B; pendingTreasury = 0
+    Note over A: Safe A loses withdrawal rights
 ```
 
 ### Solvency Failure (Bet Rejected)
@@ -110,11 +161,17 @@ sequenceDiagram
 
 4. **Per-match cap**: `matchLiability[match] + netExposure <= maxLiabilityPerMatchBps × totalAssets() / 10_000`.
 
-5. **MATCH_ROLE whitelist**: Only match proxies granted `MATCH_ROLE` by the Safe can call `recordBet`, `payWinner`, `payRefund`, `settleMarket`. Unauthorized callers revert `MatchNotAuthorized`.
+5. **MATCH_ROLE whitelist**: Only match proxies granted `MATCH_ROLE` by the admin key can call `recordBet`, `payWinner`, `payRefund`, `settleMarket`. Unauthorized callers revert `MatchNotAuthorized`.
 
 6. **Cooldown**: LPs must wait `depositCooldownSeconds` after their last share receipt before withdrawing, preventing flash-NAV manipulation.
 
-7. **freeBalance gate**: LP withdrawals are bounded by `freeBalance()` — LPs cannot withdraw USDC reserved for open winning positions.
+7. **freeBalance gate**: LP withdrawals are bounded by `freeBalance()` — LPs cannot withdraw USDC reserved for open winning positions or for the treasury's accrued claim.
+
+8. **Treasury isolation**: `accruedTreasury` is never touched by winning-bet payouts. It can only change via `settleMarket` (accrues 50% of losing net stake) and `withdrawTreasury` (decreases on Safe pull). Admin cannot read or move this balance.
+
+9. **Treasury solvency bound**: `withdrawTreasury` requires `amount <= min(accruedTreasury, USDC.balance - totalLiabilities)`. Outstanding winners always have precedence over treasury pulls.
+
+10. **Inflation-attack mitigation**: `_decimalsOffset() = 6` — ctvLP has 12 decimals (USDC 6 + offset 6). First depositor cannot inflate share price cheaply.
 
 ## Monitoring
 
@@ -122,31 +179,54 @@ sequenceDiagram
 |-------|-----|--------------|
 | Pool free balance | `pool.freeBalance()` | > sum of expected winner payouts |
 | Total liabilities | `pool.totalLiabilities()` | Decreasing after market settlement |
+| Utilization | `pool.utilization()` | < 7000 bps (70%) — alert at 8000 |
 | Per-match liability | `pool.matchLiability(matchAddr)` | Within `maxLiabilityPerMatchBps` of NAV |
 | Per-market liability | `pool.marketLiability(matchAddr, marketId)` | Within `maxLiabilityPerMarketBps` of NAV |
-| LP NAV per share | `pool.convertToAssets(1e18)` | Growing (house edge compounding) |
-| Protocol fees accrued | events `WinnerPaid`, `BetRecorded` | Consistent with volume |
+| Treasury accrued | `pool.accruedTreasury()` | Monotonically ↑ until Safe withdraws |
+| Treasury withdrawable now | `pool.treasuryWithdrawable()` | ≤ accrued; gap = pool capital tied up |
+| LP NAV per share | `pool.convertToAssets(1e12)` | Growing (house edge compounding) |
 
-**Operational rule**: `pool.freeBalance() > 0` at all times. If it reaches zero, new bets are blocked until LPs deposit or open positions settle.
+**Operational rules**:
+- `pool.freeBalance() > 0` at all times. If it reaches zero, new bets are blocked.
+- `USDC.balanceOf(pool) >= totalLiabilities + accruedTreasury` is the core solvency invariant. Any deviation indicates a bug.
 
 ## Security Properties
 
-- **Checks-Effects-Interactions**: `payWinner` / `payRefund` update liability counters before calling `safeTransfer`.
-- **ReentrancyGuard**: Present on all state-changing pool functions (`recordBet`, `settleMarket`, `payWinner`, `payRefund`, `deposit`, `withdraw`, `redeem`).
+- **Checks-Effects-Interactions**: `payWinner` / `payRefund` / `withdrawTreasury` update liability/accrual counters before calling `safeTransfer`.
+- **ReentrancyGuard**: Present on all state-changing pool functions (`recordBet`, `settleMarket`, `payWinner`, `payRefund`, `withdrawTreasury`, `deposit`, `withdraw`, `redeem`).
 - **SafeERC20**: All token transfers use OpenZeppelin's `SafeERC20` wrappers.
-- **Pausable**: Pool can be paused by `PAUSER_ROLE` — blocks all deposits, withdrawals, and match operations simultaneously.
-- **UUPS upgradeable**: Pool logic can be upgraded by Safe (`DEFAULT_ADMIN_ROLE`) without migrating USDC.
+- **Pausable**: Pool can be paused by `PAUSER_ROLE` (admin key) — blocks all deposits, withdrawals, treasury pulls, and match operations simultaneously.
+- **UUPS upgradeable**: Pool logic can be upgraded by the admin key. Storage layout is append-only; upgrade path preserves all live data.
+- **Role separation**: admin key (`DEFAULT_ADMIN_ROLE`) and treasury Safe (`treasury` state var) are disjoint. See [treasury.md](treasury.md).
 
-## What Requires Safe Execution
+## Who Can Do What
 
-| Action | Who | How |
-|--------|-----|-----|
-| Authorize match proxy | Safe (`DEFAULT_ADMIN_ROLE`) | `pool.authorizeMatch(matchProxy)` |
-| Revoke match proxy | Safe (`DEFAULT_ADMIN_ROLE`) | `pool.revokeMatch(matchProxy)` |
-| Set protocol fee | Safe (`DEFAULT_ADMIN_ROLE`) | `pool.setProtocolFeeBps(newBps)` |
-| Set liability caps | Safe (`DEFAULT_ADMIN_ROLE`) | `pool.setMaxLiabilityPerMarketBps(bps)` / `pool.setMaxLiabilityPerMatchBps(bps)` |
-| Set deposit cooldown | Safe (`DEFAULT_ADMIN_ROLE`) | `pool.setDepositCooldownSeconds(seconds)` |
-| Pause / unpause pool | `PAUSER_ROLE` / Safe | `pool.pause()` / `pool.unpause()` |
-| Upgrade pool logic | Safe (`DEFAULT_ADMIN_ROLE`) | `pool.upgradeToAndCall(newImpl, "")` |
+Admin key (`DEFAULT_ADMIN_ROLE` / `PAUSER_ROLE`):
+
+| Action | How |
+|--------|-----|
+| Authorize / revoke a match | `pool.authorizeMatch(matchProxy)` / `pool.revokeMatch(matchProxy)` |
+| Set protocol fee | `pool.setProtocolFeeBps(newBps)` (≤ 1000) |
+| Set liability caps | `pool.setMaxLiabilityPerMarketBps(bps)` / `pool.setMaxLiabilityPerMatchBps(bps)` |
+| Set per-bet cap | `pool.setMaxBetAmount(newAmount)` (0 disables) |
+| Set deposit cooldown | `pool.setDepositCooldownSeconds(seconds)` |
+| Pause / unpause pool | `pool.pause()` / `pool.unpause()` |
+| Upgrade pool logic | `pool.upgradeToAndCall(newImpl, "")` |
+
+Treasury Safe (`treasury` state variable):
+
+| Action | How |
+|--------|-----|
+| Start rotation to a new Safe | `pool.proposeTreasury(newSafe)` |
+| Cancel a pending proposal | `pool.cancelTreasuryProposal()` |
+| Accept incoming rotation (new Safe) | `pool.acceptTreasury()` |
+| Withdraw accrued USDC | `pool.withdrawTreasury(amount)` — always sends to `treasury` |
+
+Each BettingMatch (per-match admin):
+
+| Action | How |
+|--------|-----|
+| Set per-match soft odds cap | `match.setMaxAllowedOdds(maxOdds)` (0 disables; uses MAX_ODDS = 100x) |
+| Grant RESOLVER | `match.grantRole(RESOLVER_ROLE, oracle)` |
 
 Everything else (betting, claiming, resolving) is automated on-chain.

--- a/chiliz-tv/docs/treasury.md
+++ b/chiliz-tv/docs/treasury.md
@@ -1,186 +1,299 @@
-# Treasury & Gnosis Safe Operations
+# Treasury & Safe Operations
+
+> **Last reviewed:** 2026-04-22 — role separation refactor.
 
 ## Architecture
 
-Each network has **one Gnosis Safe** that serves as the treasury. The Safe:
-- Holds `DEFAULT_ADMIN_ROLE` on the `LiquidityPool` (authorizes matches, sets parameters, upgrades)
-- Is the `treasury` address on `LiquidityPool` (receives protocol fees skimmed from stakes)
-- Optionally holds admin roles on `BettingMatchFactory`, `StreamWalletFactory`, `ChilizSwapRouter`
+Treasury authority on `LiquidityPool` is split between **two distinct keys**.
+Conflating them defeats the whole defence:
+
+| Key | Role | What it can do | What it CANNOT do |
+|---|---|---|---|
+| **Admin key** (EOA or Safe) | `DEFAULT_ADMIN_ROLE` + `PAUSER_ROLE` | `authorizeMatch` / `revokeMatch`, set caps & fees & cooldown, `setMaxBetAmount`, pause / unpause, UUPS upgrades | Rotate treasury, touch `accruedTreasury`, withdraw USDC |
+| **Treasury Safe** | `treasury` (state variable — NOT a role) | `proposeTreasury` / `cancelTreasuryProposal`, `acceptTreasury`, `withdrawTreasury` | Authorize matches, set fees, pause, upgrade contracts |
 
 ```
-┌──────────────────────────────┐
-│  Gnosis Safe (Treasury)      │
-│                              │
-│  DEFAULT_ADMIN_ROLE on:      │
-│  - LiquidityPool             │
-│  - BettingMatchFactory       │
-│  - ChilizSwapRouter          │
-└──────────────┬───────────────┘
-               │ authorizeMatch() / setProtocolFeeBps() / pause() / upgrade
-               ▼
-┌──────────────────────────────┐
-│  LiquidityPool (ERC-4626)    │◄──── BettingMatch proxies call:
-│  Single USDC vault           │      recordBet / payWinner / payRefund / settleMarket
-│  treasury = Safe address     │
-└──────────────────────────────┘
-               ▲
-               │ deposit USDC → receive ctvLP shares
-┌──────────────────────────────┐
-│  Liquidity Providers (LPs)   │
-└──────────────────────────────┘
+┌─────────────────────────────┐        ┌─────────────────────────────┐
+│  Admin key                  │        │  Treasury Safe              │
+│  DEFAULT_ADMIN_ROLE         │        │  state: `treasury`          │
+│  PAUSER_ROLE                │        │                             │
+├─────────────────────────────┤        ├─────────────────────────────┤
+│ • authorizeMatch            │        │ • proposeTreasury (2-step)  │
+│ • revokeMatch               │        │ • cancelTreasuryProposal    │
+│ • setProtocolFeeBps         │        │ • acceptTreasury            │
+│ • setMaxLiabilityPerMarketBps│       │ • withdrawTreasury          │
+│ • setMaxLiabilityPerMatchBps │       │                             │
+│ • setDepositCooldownSeconds  │       │                             │
+│ • setMaxBetAmount           │        │                             │
+│ • pause / unpause           │        │                             │
+│ • UUPS upgrade              │        │                             │
+└──────────────┬──────────────┘        └──────────────┬──────────────┘
+               │                                      │
+               └──────────────────┬───────────────────┘
+                                  ▼
+              ┌─────────────────────────────────────────┐
+              │  LiquidityPool (ERC-4626, UUPS)         │
+              │  - USDC vault                           │
+              │  - `accruedTreasury` (pull claim)       │
+              │  - 50/50 loss split on settlement       │
+              └─────────────────────────────────────────┘
+                                  ▲
+                                  │ deposit / withdraw
+              ┌─────────────────────────────────────────┐
+              │  Liquidity Providers (ctvLP holders)    │
+              └─────────────────────────────────────────┘
 ```
 
-## Initial Setup (After Deployment)
+### Why the separation matters
 
-### 1. Authorize Each BettingMatch Proxy
+- **Admin compromise** cannot redirect funds. The admin key holds no authority over `treasury` or `accruedTreasury`.
+- **Treasury compromise** cannot brick the protocol. The Safe can take the accrued balance but cannot revoke matches, change parameters, or upgrade the contract.
 
-For every match contract, the Safe executes:
+Deploy with **different addresses** for `admin_` and `treasury_` in `LiquidityPool.initialize(...)`. The contract does not enforce this invariant — it is a deployment discipline.
+
+---
+
+## How value accrues to the treasury
+
+The pool splits every losing stake 50/50: LPs get half (compounded into ctvLP NAV), the treasury gets the other half booked as an **accrued claim** that stays as USDC inside the pool until the Safe pulls it.
+
+```
+Bettor loses netStake  ──▶  LiquidityPool.settleMarket(..., losingNetStake)
+                                │
+                                ├─ accruedTreasury += losingNetStake × 50% / 10_000
+                                └─ remaining 50% stays as pool USDC → LP NAV
+```
+
+- **No push.** Nothing transfers to the treasury on settlement.
+- **No dilution.** `totalAssets()` subtracts `accruedTreasury` so LP share price does not reflect the treasury's share.
+- **Pool solvency first.** `withdrawTreasury(amount)` reverts if `amount > USDC balance − totalLiabilities`. Bettors with outstanding bets always have precedence.
+
+The constant split is on-chain: `TREASURY_SHARE_BPS = 5000`. Not admin-configurable by design — predictability for LPs.
+
+---
+
+## Initial Setup (after deployment)
+
+### 1. Verify role separation
+
+```solidity
+pool.hasRole(DEFAULT_ADMIN_ROLE, safeAddress)  // expect FALSE
+pool.hasRole(DEFAULT_ADMIN_ROLE, adminAddress) // expect TRUE
+pool.treasury() == safeAddress                 // expect TRUE
+```
+
+If the Safe accidentally ended up as admin, rotate admin (`grantRole` from the Safe-qua-admin to the new admin EOA, then `renounceRole`). This is cheap to fix pre-launch, expensive to fix post-launch.
+
+### 2. Authorize each BettingMatch proxy
+
+Admin tx (Safe can also act as admin if this is the only path you have):
 
 ```
 Target:   LiquidityPool
 Function: authorizeMatch(address matchContract)
-Params:   matchContract = <BettingMatch proxy address>
-Effect:   Grants MATCH_ROLE to the proxy
+Effect:   Grants MATCH_ROLE → the proxy can call recordBet/payWinner/payRefund/settleMarket
 ```
 
-### 2. Configure Liability Caps (Optional — has sane defaults)
+### 3. Configure risk caps (have sensible defaults)
 
 ```
-Target:   LiquidityPool
-Function: setMaxLiabilityPerMarketBps(uint16 bps)
-Params:   bps = max per-market exposure as bps of totalAssets() (e.g. 500 = 5%)
-
-Target:   LiquidityPool
-Function: setMaxLiabilityPerMatchBps(uint16 bps)
-Params:   bps = max per-match exposure as bps of totalAssets() (e.g. 2000 = 20%)
+LiquidityPool.setMaxLiabilityPerMarketBps(uint16)  // e.g. 500  = 5%   of totalAssets
+LiquidityPool.setMaxLiabilityPerMatchBps(uint16)   // e.g. 2000 = 20%  of totalAssets
+LiquidityPool.setMaxBetAmount(uint256)             // e.g. 10_000e6 (10k USDC/bet), 0 = disabled
+LiquidityPool.setDepositCooldownSeconds(uint48)    // e.g. 3600 (1h anti-flash-NAV)
 ```
 
-### 3. Seed Initial Liquidity (Safe can act as first LP)
-
-The Safe (or any LP) deposits USDC directly:
+Each BettingMatch also has its own soft odds cap:
 
 ```
-Target:   <USDC token address>
-Function: approve(address spender, uint256 amount)
-Params:   spender = <LiquidityPool address>
-          amount  = <deposit amount in 6-decimal USDC>
-
-Target:   <LiquidityPool address>
-Function: deposit(uint256 assets, address receiver)
-Params:   assets   = <same deposit amount>
-          receiver = <Safe address or LP address>
+BettingMatch.setMaxAllowedOdds(uint32)             // e.g. 50_000 = 5.00x; 0 = uses MAX_ODDS (100x)
 ```
 
-## Operational Runbook
+### 4. Seed initial liquidity
 
-### Monitoring Pool Health
-
-Query these view functions periodically (e.g., every hour):
-
-| Check | Call | Healthy When |
-|-------|------|--------------|
-| Free balance | `pool.freeBalance()` | > 0; ideally > projected max payout |
-| Total liabilities | `pool.totalLiabilities()` | Decreasing after settlement windows |
-| NAV per share | `pool.convertToAssets(1e18)` | Stable or growing (house edge compounding) |
-| Per-match liability | `pool.matchLiability(matchAddr)` | < `maxLiabilityPerMatchBps × totalAssets / 10_000` |
-
-**Alert threshold**: `pool.freeBalance() < 10% of pool.totalAssets()` — new bets approaching cap.
-
-### Emergency: Pause Pool
-
-If suspicious activity is detected:
+The Safe (or any LP) deposits USDC directly. `_decimalsOffset = 6` defuses the classic first-depositor inflation attack — any deposit is safe.
 
 ```
-Target:   LiquidityPool
-Function: pause()
-Effect:   All deposits, withdrawals, and match operations (recordBet, payWinner, etc.) blocked
+USDC.approve(pool, amount)
+LiquidityPool.deposit(amount, receiverAddress)
 ```
 
-To resume: `pool.unpause()` (requires `DEFAULT_ADMIN_ROLE`)
+---
 
-### Revoking a Match
+## Treasury rotation (2-step)
 
-If a match contract is compromised or decommissioned:
-
-```
-Target:   LiquidityPool
-Function: revokeMatch(address matchContract)
-Effect:   Revokes MATCH_ROLE — match can no longer record bets or trigger payouts
-```
-
-### Adjusting Protocol Fee
+Rotation is gated to the **current treasury only**. Admin cannot rotate.
 
 ```
-Target:   LiquidityPool
-Function: setProtocolFeeBps(uint16 newBps)
-Params:   newBps <= 1000 (10% maximum)
-Effect:   New fee applied on subsequent bets; accrues to treasury address
+┌──────────────┐            ┌──────────────┐
+│  Safe A      │            │  Safe B      │
+│ (current)    │            │ (target)     │
+└──────┬───────┘            └──────┬───────┘
+       │ 1. proposeTreasury(B)     │
+       ├──────────────────────────▶│  pendingTreasury = B
+       │                           │  Safe A still holds withdrawal rights
+       │                           │
+       │                           │ 2. acceptTreasury() (from Safe B)
+       │                           ├────────────────────┐
+       │                           │                    ▼
+       │                                          treasury = B
+       │                                          pendingTreasury = 0
 ```
 
-## Network Configuration
+Common patterns:
 
-Treasury addresses and contract addresses are stored in `config/<network>.json`:
+- **Typo in propose:** Safe A calls `cancelTreasuryProposal()` — pending cleared, nothing changed.
+- **Safe B mis-configured (can't sign):** `acceptTreasury` never arrives. Safe A stays in charge indefinitely. No funds moved.
+- **Propose slipped through A's multisig hostilely:** accrued balance is safe — only Safe B can complete the rotation. Safe A can cancel before B signs.
+
+This is the exact pattern of OZ `Ownable2Step` — it protects against the single class of error that has no recovery path (once accepted, old treasury loses all rights).
+
+### Safe transaction templates
+
+**Propose rotation (Safe A):**
 
 ```json
 {
-  "chainId": 88882,
-  "rpcUrl": "https://spicy-rpc.chiliz.com",
-  "safeAddress": "0x...",
-  "usdc": "0x...",
-  "liquidityPool": "0x...",
-  "matches": [
-    "0x...",
-    "0x..."
-  ]
+  "to": "<LiquidityPool>",
+  "value": "0",
+  "data": "proposeTreasury(address)",
+  "params": ["<Safe B address>"]
 }
 ```
 
-## Safe Transaction Templates
-
-### Batch: Authorize New Match + Set Caps
+**Accept rotation (Safe B):**
 
 ```json
-[
-  {
-    "to": "<LiquidityPool>",
-    "value": "0",
-    "data": "authorizeMatch(address)",
-    "params": ["<newMatchProxy>"]
-  },
-  {
-    "to": "<LiquidityPool>",
-    "value": "0",
-    "data": "setMaxLiabilityPerMatchBps(uint16)",
-    "params": ["2000"]
-  }
-]
+{
+  "to": "<LiquidityPool>",
+  "value": "0",
+  "data": "acceptTreasury()",
+  "params": []
+}
 ```
 
-### Batch: Seed Liquidity
+**Cancel (Safe A):**
 
 ```json
-[
-  {
-    "to": "<USDC>",
-    "value": "0",
-    "data": "approve(address,uint256)",
-    "params": ["<LiquidityPool>", "10000000000"]
-  },
-  {
-    "to": "<LiquidityPool>",
-    "value": "0",
-    "data": "deposit(uint256,address)",
-    "params": ["10000000000", "<Safe address>"]
-  }
-]
+{
+  "to": "<LiquidityPool>",
+  "value": "0",
+  "data": "cancelTreasuryProposal()",
+  "params": []
+}
 ```
 
-## Cost Estimates
+---
+
+## Withdrawing accrued funds
+
+```solidity
+uint256 available = pool.treasuryWithdrawable();
+// available = min(accruedTreasury, USDC.balanceOf(pool) - totalLiabilities)
+pool.withdrawTreasury(amount);  // amount <= available
+```
+
+- Always sends to `treasury` (no `to` parameter). The Safe pulls to itself; forward from there if needed.
+- Reverts `InsufficientTreasuryBalance` if requesting more than `treasuryWithdrawable`.
+- Reverts `NotTreasury` for any caller except the current treasury address.
+- LP NAV is unchanged by any valid withdrawal (the claim was already excluded from `totalAssets()`).
+
+**When to leave funds in vs. withdraw.** Leaving accrued balance inside the pool effectively lets the team participate as house capital (funds back bet liabilities until withdrawn, but don't dilute LPs). Withdrawing pulls the claim out for off-chain deployment.
+
+**Safe transaction template:**
+
+```json
+{
+  "to": "<LiquidityPool>",
+  "value": "0",
+  "data": "withdrawTreasury(uint256)",
+  "params": ["500000000"]
+}
+```
+
+---
+
+## Operational Runbook
+
+### Monitoring pool health (hourly)
+
+| Check | Call | Healthy when |
+|---|---|---|
+| LP NAV | `pool.totalAssets()` | > 0, trending up over time |
+| Free balance for LP exits | `pool.freeBalance()` | > 0 |
+| Utilization | `pool.utilization()` | < 7000 bps (70%) — alert at 8000 |
+| Total bet liabilities | `pool.totalLiabilities()` | Decreases after settlement windows |
+| Treasury accrued | `pool.accruedTreasury()` | Monotonically ↑ until withdrawn |
+| Treasury withdrawable right now | `pool.treasuryWithdrawable()` | ≤ accruedTreasury; gap = USDC tied up in bets |
+| NAV / share | `pool.convertToAssets(1e12)` | Stable or growing |
+| Per-match liability | `pool.matchLiability(matchAddr)` | < `maxLiabilityPerMatchBps × totalAssets() / 10_000` |
+
+**Alert thresholds:**
+- `utilization() > 8000 bps` → too much LP capital tied up, exits may cap
+- `freeBalance() < 10% × totalAssets()` → new bets approaching solvency floor
+- `accruedTreasury` growing but `treasuryWithdrawable` flat → pool fully deployed to bets (acceptable short-term, watch for settlement)
+
+### Emergency: pause pool
+
+```
+LiquidityPool.pause()  // PAUSER_ROLE (admin key)
+```
+
+Blocks all deposits, withdrawals, `recordBet`, `settleMarket`, `payWinner`, `payRefund`, and `withdrawTreasury`. Resume with `unpause()` from admin.
+
+### Revoking a compromised or decommissioned match
+
+```
+LiquidityPool.revokeMatch(matchProxy)  // DEFAULT_ADMIN_ROLE
+```
+
+Match can no longer record bets or trigger payouts. Pre-existing liabilities remain but can only be released by a fresh authorization.
+
+### Adjusting parameters
+
+| Change | Caller | Function |
+|---|---|---|
+| Protocol fee | Admin | `setProtocolFeeBps(newBps)` — ≤ 1000 (10%) |
+| Per-market cap | Admin | `setMaxLiabilityPerMarketBps(newBps)` |
+| Per-match cap | Admin | `setMaxLiabilityPerMatchBps(newBps)` |
+| Per-bet cap | Admin | `setMaxBetAmount(newAmount)` — 0 disables |
+| Withdraw cooldown | Admin | `setDepositCooldownSeconds(newSeconds)` |
+| Max odds (per match) | Match admin | `BettingMatch.setMaxAllowedOdds(newMax)` |
+| Rotate treasury | Treasury (Safe) | `proposeTreasury` → `acceptTreasury` |
+| Pull accrued funds | Treasury (Safe) | `withdrawTreasury(amount)` |
+| Pause | Admin | `pause()` |
+
+---
+
+## Network Configuration
+
+Stored in `config/<network>.json`:
+
+```json
+{
+  "chainId": 88888,
+  "rpcUrl": "https://rpc.chiliz.com",
+  "adminKey":    "0x...",
+  "treasurySafe":"0x...",
+  "usdc":        "0x...",
+  "liquidityPool":"0x...",
+  "matches": ["0x...", "0x..."]
+}
+```
+
+Keep `adminKey` and `treasurySafe` distinct. The deploy script MUST pass them as separate `initialize()` arguments.
+
+---
+
+## Cost estimates
 
 | Operation | Approx. Gas |
-|-----------|-------------|
+|---|---|
 | `pool.authorizeMatch()` | ~50,000 |
-| `pool.deposit()` | ~90,000 |
+| `pool.deposit()` | ~95,000 |
 | `pool.withdraw()` | ~95,000 |
+| `pool.withdrawTreasury()` | ~55,000 |
+| `pool.proposeTreasury()` | ~30,000 |
+| `pool.acceptTreasury()` | ~35,000 |
 | `claim()` (pool pays winner) | ~100,000 |
 | `claimAll()` (N bets) | ~70,000 + N×50,000 |

--- a/chiliz-tv/script/DeployAll.s.sol
+++ b/chiliz-tv/script/DeployAll.s.sol
@@ -12,7 +12,12 @@ import {StreamWalletFactory} from "../src/streamer/StreamWalletFactory.sol";
 // Unified swap router
 import {ChilizSwapRouter} from "../src/swap/ChilizSwapRouter.sol";
 
-// PayoutEscrow is deployed per-match by BettingMatchFactory — no shared escrow
+// NOTE (2026-04-22): USDC custody lives in `LiquidityPool` (single shared
+// ERC-4626 vault). Deploy it separately via `script/DeployLiquidityPool.s.sol`
+// — it requires distinct admin and treasury addresses and is intentionally
+// kept out of this all-in-one script. After pool + factory are deployed,
+// wire each match via `pool.authorizeMatch(matchProxy)` from the admin key
+// and `match.setLiquidityPool(pool)` from the match admin.
 
 /**
  * @title DeployAll
@@ -172,7 +177,9 @@ contract DeployAll is Script {
         console.log("BettingMatchFactory:", address(bettingFactory));
         console.log("StreamWalletFactory:", address(streamFactory));
         console.log("ChilizSwapRouter:   ", address(swapRouter));
-        console.log("Note: PayoutEscrow is deployed per-match by BettingMatchFactory");
+        console.log("");
+        console.log("MISSING (deploy separately):");
+        console.log("  LiquidityPool    <- script/DeployLiquidityPool.s.sol");
         console.log("=========================================");
         console.log("");
     }
@@ -180,14 +187,20 @@ contract DeployAll is Script {
     function _printPostDeploymentSteps() internal view {
         console.log("POST-DEPLOYMENT STEPS:");
         console.log("======================");
-        console.log("1. For each BettingMatch (proxy + escrow deployed together by factory):");
+        console.log("0. Deploy LiquidityPool (separate script -- requires distinct");
+        console.log("   ADMIN_ADDRESS and SAFE_ADDRESS envs):");
+        console.log("   forge script script/DeployLiquidityPool.s.sol --rpc-url $RPC_URL --broadcast");
+        console.log("");
+        console.log("1. For each BettingMatch proxy created by the factory:");
         console.log("   a) cast send <MATCH> 'setUSDCToken(address)'", usdcAddress);
-        console.log("   b) cast send <MATCH> 'grantRole(bytes32,address)' $(cast keccak 'SWAP_ROUTER_ROLE')", address(swapRouter));
-        console.log("   c) Escrow is wired at deploy time - no authorizeMatch needed");
-        console.log("2. Fund each match's dedicated escrow with USDC (from Safe):");
-        console.log("   Step A: cast send <USDC> 'approve(address,uint256)' <MATCH_ESCROW> <AMOUNT>");
-        console.log("   Step B: cast send <MATCH_ESCROW> 'fund(uint256)' <AMOUNT>");
-        console.log("   Note: get escrow address via BettingMatchFactory.getEscrow(<MATCH>)");
+        console.log("   b) cast send <MATCH> 'setLiquidityPool(address)' <LIQUIDITY_POOL>");
+        console.log("   c) cast send <LIQUIDITY_POOL> 'authorizeMatch(address)' <MATCH>   # from ADMIN_ADDRESS");
+        console.log("   d) cast send <MATCH> 'grantRole(bytes32,address)' $(cast keccak 'SWAP_ROUTER_ROLE')", address(swapRouter));
+        console.log("   e) cast send <MATCH> 'grantRole(bytes32,address)' $(cast keccak 'RESOLVER_ROLE') <ORACLE>");
+        console.log("   f) cast send <MATCH> 'setMaxAllowedOdds(uint32)' <cap>   # recommended");
+        console.log("2. Seed LiquidityPool with USDC:");
+        console.log("   Step A: cast send <USDC> 'approve(address,uint256)' <LIQUIDITY_POOL> <AMOUNT>");
+        console.log("   Step B: cast send <LIQUIDITY_POOL> 'deposit(uint256,address)' <AMOUNT> <RECEIVER>");
         console.log("=========================================");
     }
 }

--- a/chiliz-tv/script/DeployLiquidityPool.s.sol
+++ b/chiliz-tv/script/DeployLiquidityPool.s.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {Script, console} from "forge-std/Script.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {LiquidityPool} from "../src/liquidity/LiquidityPool.sol";
+
+/**
+ * @title DeployLiquidityPool
+ * @author ChilizTV
+ * @notice Deploys the ERC-4626 LiquidityPool as a UUPS proxy.
+ *
+ * ROLE SEPARATION (critical):
+ * ===========================
+ * The pool enforces a hard split between two authorities:
+ *
+ *   - ADMIN_ADDRESS: holds DEFAULT_ADMIN_ROLE + PAUSER_ROLE. Runs operational
+ *                    setters (authorizeMatch, fees, caps, pause, UUPS upgrades).
+ *                    Can NOT touch accruedTreasury or rotate `treasury`.
+ *   - SAFE_ADDRESS:  stored in `treasury` state. Only address that can call
+ *                    proposeTreasury / acceptTreasury / cancelTreasuryProposal
+ *                    and withdrawTreasury. Can NOT authorize matches, set fees,
+ *                    pause, or upgrade.
+ *
+ * These MUST be different addresses. The script reverts if you pass the same.
+ *
+ * ENVIRONMENT VARIABLES (required):
+ * =================================
+ *   PRIVATE_KEY               - Deployer private key
+ *   RPC_URL                   - Network RPC endpoint
+ *   SAFE_ADDRESS              - Treasury Safe multisig (will hold `treasury` state)
+ *   ADMIN_ADDRESS             - Admin key (DEFAULT_ADMIN_ROLE + PAUSER_ROLE).
+ *                               MUST be distinct from SAFE_ADDRESS.
+ *   USDC_ADDRESS              - USDC token address (vault asset)
+ *
+ * OPTIONAL (have sensible defaults):
+ * ==================================
+ *   PROTOCOL_FEE_BPS          - Stake skim at bet placement (default 200 = 2%, max 1000)
+ *   MAX_MARKET_LIAB_BPS       - Per-market liability cap (default 500  = 5%)
+ *   MAX_MATCH_LIAB_BPS        - Per-match liability cap  (default 2000 = 20%)
+ *   DEPOSIT_COOLDOWN_SECS     - LP withdrawal cooldown (default 3600 = 1h)
+ *   MAX_BET_AMOUNT            - Pool-wide per-bet cap in USDC atomic units
+ *                               (default 10_000e6 = 10k USDC; 0 disables).
+ *                               Set via post-init setMaxBetAmount call.
+ *
+ * USAGE:
+ * ======
+ *   forge script script/DeployLiquidityPool.s.sol \
+ *     --rpc-url $RPC_URL --broadcast --verify -vvvv
+ */
+contract DeployLiquidityPool is Script {
+
+    LiquidityPool public pool;
+
+    address public deployer;
+    address public safeAddress;
+    address public adminAddress;
+    address public usdcAddress;
+
+    uint16 public protocolFeeBps;
+    uint16 public maxMarketLiabBps;
+    uint16 public maxMatchLiabBps;
+    uint48 public depositCooldownSecs;
+    uint256 public maxBetAmount;
+
+    function run() external {
+        deployer = msg.sender;
+        _loadConfig();
+
+        vm.startBroadcast();
+
+        _printHeader();
+        _deployPool();
+        _postInitSetters();
+        _printSummary();
+
+        vm.stopBroadcast();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+
+    function _loadConfig() internal {
+        safeAddress  = vm.envAddress("SAFE_ADDRESS");
+        adminAddress = vm.envAddress("ADMIN_ADDRESS");
+        usdcAddress  = vm.envAddress("USDC_ADDRESS");
+
+        require(safeAddress  != address(0), "SAFE_ADDRESS required");
+        require(adminAddress != address(0), "ADMIN_ADDRESS required");
+        require(usdcAddress  != address(0), "USDC_ADDRESS required");
+        require(
+            safeAddress != adminAddress,
+            "SAFE_ADDRESS and ADMIN_ADDRESS MUST be distinct"
+        );
+
+        protocolFeeBps      = uint16(_envUintOr("PROTOCOL_FEE_BPS",        200));
+        maxMarketLiabBps    = uint16(_envUintOr("MAX_MARKET_LIAB_BPS",     500));
+        maxMatchLiabBps     = uint16(_envUintOr("MAX_MATCH_LIAB_BPS",     2000));
+        depositCooldownSecs = uint48(_envUintOr("DEPOSIT_COOLDOWN_SECS", 3_600));
+        maxBetAmount        =        _envUintOr("MAX_BET_AMOUNT",     10_000e6);
+    }
+
+    function _deployPool() internal {
+        console.log("[1/2] Deploying LiquidityPool");
+        console.log("==============================");
+
+        LiquidityPool impl = new LiquidityPool();
+        console.log("  Implementation:", address(impl));
+
+        bytes memory initData = abi.encodeWithSelector(
+            LiquidityPool.initialize.selector,
+            IERC20(usdcAddress),
+            adminAddress,
+            safeAddress,
+            protocolFeeBps,
+            maxMarketLiabBps,
+            maxMatchLiabBps,
+            depositCooldownSecs
+        );
+
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        pool = LiquidityPool(address(proxy));
+        console.log("  Proxy:         ", address(pool));
+        console.log("  Admin (DEFAULT_ADMIN_ROLE):", adminAddress);
+        console.log("  Treasury (state var):      ", safeAddress);
+        console.log("");
+    }
+
+    function _postInitSetters() internal view {
+        console.log("[2/2] Post-init configuration");
+        console.log("==============================");
+
+        if (maxBetAmount != 0) {
+            // setMaxBetAmount is DEFAULT_ADMIN_ROLE-gated — deployer will NOT
+            // hold it; the admin address does. Emit a reminder instead of
+            // attempting the call from the wrong key.
+            console.log("  NOTE: `maxBetAmount` is DEFAULT_ADMIN_ROLE-gated.");
+            console.log("  After deployment, call from ADMIN_ADDRESS:");
+            console.log("    cast send <pool> 'setMaxBetAmount(uint256)'", maxBetAmount);
+        } else {
+            console.log("  maxBetAmount disabled (0)");
+        }
+        console.log("");
+    }
+
+    function _printHeader() internal view {
+        console.log("=========================================");
+        console.log("CHILIZ-TV LIQUIDITY POOL DEPLOYMENT");
+        console.log("=========================================");
+        console.log("Deployer:            ", deployer);
+        console.log("USDC:                ", usdcAddress);
+        console.log("Admin address:       ", adminAddress);
+        console.log("Treasury (Safe):     ", safeAddress);
+        console.log("Protocol fee (bps):  ", protocolFeeBps);
+        console.log("Max market liab bps: ", maxMarketLiabBps);
+        console.log("Max match liab bps:  ", maxMatchLiabBps);
+        console.log("Withdraw cooldown s: ", depositCooldownSecs);
+        console.log("Max bet amount:      ", maxBetAmount);
+        console.log("=========================================");
+        console.log("");
+    }
+
+    function _printSummary() internal view {
+        console.log("=========================================");
+        console.log("DEPLOYMENT COMPLETE");
+        console.log("=========================================");
+        console.log("LiquidityPool proxy:", address(pool));
+        console.log("");
+        console.log("POST-DEPLOYMENT STEPS:");
+        console.log("======================");
+        console.log("1. For each existing BettingMatch proxy, from ADMIN_ADDRESS:");
+        console.log("   cast send <pool> 'authorizeMatch(address)' <matchProxy>");
+        console.log("");
+        console.log("2. On each BettingMatch, from match ADMIN_ROLE:");
+        console.log("   cast send <match> 'setLiquidityPool(address)' <pool>");
+        console.log("   cast send <match> 'setUSDCToken(address)'     <usdc>");
+        console.log("   cast send <match> 'setMaxAllowedOdds(uint32)' <cap>  # recommended");
+        console.log("");
+        console.log("3. Optional: set per-bet cap from ADMIN_ADDRESS:");
+        console.log("   cast send <pool> 'setMaxBetAmount(uint256)'", maxBetAmount);
+        console.log("");
+        console.log("4. Seed initial LP capital (can be Safe itself):");
+        console.log("   cast send <usdc> 'approve(address,uint256)' <pool> <amount>");
+        console.log("   cast send <pool> 'deposit(uint256,address)' <amount> <receiver>");
+        console.log("=========================================");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    function _envUintOr(string memory key, uint256 defaultVal)
+        internal
+        view
+        returns (uint256)
+    {
+        try vm.envUint(key) returns (uint256 v) { return v; }
+        catch { return defaultVal; }
+    }
+}

--- a/chiliz-tv/script/README.md
+++ b/chiliz-tv/script/README.md
@@ -34,7 +34,11 @@ Create a `.env` file in the `chiliz-tv` directory:
 ```bash
 # Required for deployment
 PRIVATE_KEY=0x...           # Deployer private key
-SAFE_ADDRESS=0x...          # Gnosis Safe multisig (treasury)
+SAFE_ADDRESS=0x...          # Treasury Safe multisig — holds `treasury` on LiquidityPool.
+                            # Controls `withdrawTreasury` and 2-step treasury rotation.
+ADMIN_ADDRESS=0x...         # Admin key for LiquidityPool DEFAULT_ADMIN_ROLE.
+                            # MUST be distinct from SAFE_ADDRESS. Controls authorize/revoke
+                            # matches, fee/cap setters, pause, and UUPS upgrades.
 
 # Optional for match setup
 FACTORY_ADDRESS=0x...       # BettingMatchFactory address (for SetupFootballMatch)
@@ -136,15 +140,16 @@ cast send $MATCH_ADDRESS \
   $CHILIZ_SWAP_ROUTER \
   --rpc-url $RPC_URL --private-key $PRIVATE_KEY
 
-# 3. Fund USDC treasury (for paying out USDC wins)
+# 3. Seed LiquidityPool with USDC (backs bet payouts)
+# Note: the match contract no longer holds USDC. All bet custody is on LiquidityPool.
 cast send $USDC_ADDRESS \
   "approve(address,uint256)" \
-  $MATCH_ADDRESS $AMOUNT \
+  $LIQUIDITY_POOL $AMOUNT \
   --rpc-url $RPC_URL --private-key $PRIVATE_KEY
 
-cast send $MATCH_ADDRESS \
-  "fundUSDCTreasury(uint256)" \
-  $AMOUNT \
+cast send $LIQUIDITY_POOL \
+  "deposit(uint256,address)" \
+  $AMOUNT $SAFE_ADDRESS \
   --rpc-url $RPC_URL --private-key $PRIVATE_KEY
 
 # 4. Test a swap bet (send native CHZ, auto-swaps to USDC)
@@ -315,15 +320,28 @@ cast send $STREAM_FACTORY \
 
 ## Access Control Roles
 
+**On each BettingMatch:**
+
 | Role | Permissions |
 |------|-------------|
 | `DEFAULT_ADMIN_ROLE` | Grant/revoke all roles, upgrade contract |
-| `ADMIN_ROLE` | Add markets, change market state |
+| `ADMIN_ROLE` | Add markets, change market state, `setMaxAllowedOdds`, `setUSDCToken`, `setLiquidityPool` |
 | `ODDS_SETTER_ROLE` | Update market odds |
 | `RESOLVER_ROLE` | Resolve markets with results |
 | `PAUSER_ROLE` | Pause/unpause contract |
-| `TREASURY_ROLE` | Emergency fund withdrawal |
 | `SWAP_ROUTER_ROLE` | Call `placeBetUSDCFor()` on behalf of users (ChilizSwapRouter) |
+
+> The match contract no longer holds USDC — all bet custody is on `LiquidityPool`. The old `TREASURY_ROLE` was removed with that migration.
+
+**On `LiquidityPool`:**
+
+| Role / authority | Who holds it | Permissions |
+|---|---|---|
+| `DEFAULT_ADMIN_ROLE` | Admin key (EOA or ops multisig — NOT the treasury Safe) | Authorize/revoke matches, set fee / caps / cooldown / `maxBetAmount`, upgrade |
+| `PAUSER_ROLE` | Admin key | Emergency pause |
+| `MATCH_ROLE` | Each BettingMatch proxy | Call `recordBet` / `settleMarket` / `payWinner` / `payRefund` |
+| `ROUTER_ROLE` | ChilizSwapRouter | Call `recordBet` on behalf of users |
+| `treasury` (state var) | Treasury Safe | `proposeTreasury` / `cancelTreasuryProposal` / `acceptTreasury` / `withdrawTreasury` |
 
 ## Upgrading Contracts
 

--- a/chiliz-tv/script/UpgradeLiquidityPool.s.sol
+++ b/chiliz-tv/script/UpgradeLiquidityPool.s.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {Script, console} from "forge-std/Script.sol";
+import {LiquidityPool} from "../src/liquidity/LiquidityPool.sol";
+
+/**
+ * @title UpgradeLiquidityPool
+ * @author ChilizTV
+ * @notice Upgrades the LiquidityPool UUPS proxy to a new implementation.
+ *
+ *   1. Deploys a new LiquidityPool implementation.
+ *   2. Calls `upgradeToAndCall(newImpl, "")` on the proxy.
+ *      Caller MUST hold DEFAULT_ADMIN_ROLE on the proxy (admin key — NOT
+ *      the treasury Safe).
+ *
+ * STORAGE-LAYOUT SAFETY CHECKLIST — run before every upgrade:
+ * ==========================================================
+ *   forge inspect src/liquidity/LiquidityPool.sol:LiquidityPool storage-layout
+ *
+ * Diff the output against the previously deployed layout. Valid changes:
+ *   - Appending NEW slots before the `__gap` and shrinking `__gap` by the
+ *     same amount.
+ *   - Renaming variables (no storage impact).
+ *   - Adding public getters / internal functions (no storage impact).
+ *
+ * Forbidden changes:
+ *   - Reordering existing named slots.
+ *   - Deleting named slots.
+ *   - Changing the type of an existing named slot.
+ *   - Growing `__gap` without shrinking other storage (changes total footprint).
+ *
+ * ENVIRONMENT VARIABLES (required):
+ *   PRIVATE_KEY      - Admin key (holds DEFAULT_ADMIN_ROLE on proxy)
+ *   RPC_URL          - Network RPC endpoint
+ *   POOL_ADDRESS     - Deployed LiquidityPool proxy address
+ *
+ * OPTIONAL:
+ *   DRY_RUN          - Set to "true" to deploy new impl + print the upgrade
+ *                      tx, but skip the upgradeToAndCall call. Useful to
+ *                      verify implementation address before the Safe signs.
+ *
+ * USAGE:
+ *   forge script script/UpgradeLiquidityPool.s.sol \
+ *     --rpc-url $RPC_URL --broadcast --verify -vvvv
+ */
+contract UpgradeLiquidityPool is Script {
+
+    LiquidityPool public pool;
+    address public newImpl;
+    bool    public dryRun;
+
+    function run() external {
+        address poolAddr = vm.envAddress("POOL_ADDRESS");
+        pool = LiquidityPool(poolAddr);
+        dryRun = _envBool("DRY_RUN", false);
+
+        vm.startBroadcast();
+
+        _printHeader();
+        _deployNewImplementation();
+        if (!dryRun) _upgrade();
+        _printSummary();
+
+        vm.stopBroadcast();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+
+    function _deployNewImplementation() internal {
+        console.log("[1/2] Deploying new LiquidityPool implementation");
+        console.log("=================================================");
+        newImpl = address(new LiquidityPool());
+        console.log("  New implementation:", newImpl);
+        console.log("");
+    }
+
+    function _upgrade() internal {
+        console.log("[2/2] Calling upgradeToAndCall on proxy");
+        console.log("========================================");
+        pool.upgradeToAndCall(newImpl, "");
+        console.log("  upgraded", address(pool), "->", newImpl);
+        console.log("");
+    }
+
+    function _printHeader() internal view {
+        console.log("=========================================");
+        console.log("CHILIZ-TV LIQUIDITY POOL UPGRADE");
+        console.log("=========================================");
+        console.log("Proxy:          ", address(pool));
+        console.log("Caller:         ", msg.sender);
+        console.log("Dry run:        ", dryRun ? "YES (upgradeToAndCall skipped)" : "no");
+        console.log("Current treasury:", pool.treasury());
+        console.log("=========================================");
+        console.log("");
+        console.log("Before broadcasting, verify storage-layout compatibility:");
+        console.log("  forge inspect src/liquidity/LiquidityPool.sol:LiquidityPool storage-layout");
+        console.log("");
+    }
+
+    function _printSummary() internal view {
+        console.log("=========================================");
+        console.log("UPGRADE COMPLETE");
+        console.log("=========================================");
+        console.log("Proxy:              ", address(pool));
+        console.log("New implementation: ", newImpl);
+        console.log("");
+        console.log("POST-UPGRADE SANITY CHECKS:");
+        console.log("  1. View function still returns sensible value:");
+        console.log("     cast call <pool> 'totalAssets()(uint256)'");
+        console.log("     cast call <pool> 'accruedTreasury()(uint256)'");
+        console.log("  2. Role invariants intact:");
+        console.log("     cast call <pool> 'treasury()(address)'");
+        console.log("     cast call <pool> 'hasRole(bytes32,address)(bool)' \\");
+        console.log("        $(cast --to-bytes32 0x0) <expected admin>");
+        console.log("  3. Run the full forge test suite against a fork.");
+        console.log("=========================================");
+    }
+
+    function _envBool(string memory key, bool defaultVal) internal view returns (bool) {
+        try vm.envString(key) returns (string memory v) {
+            return keccak256(bytes(v)) == keccak256(bytes("true"));
+        } catch {
+            return defaultVal;
+        }
+    }
+}

--- a/chiliz-tv/src/betting/BettingMatch.sol
+++ b/chiliz-tv/src/betting/BettingMatch.sol
@@ -131,6 +131,23 @@ abstract contract BettingMatch is
     ///         full potential payout.
     mapping(uint256 => mapping(uint64 => uint256)) internal _selectionNetExposures;
 
+    /// @notice Per-market TOTAL net stake (post-fee). Running sum across
+    ///         all bets on the market; used at resolution to compute the
+    ///         losing-side net-stake total passed to `LiquidityPool.settleMarket`
+    ///         for treasury accrual.
+    mapping(uint256 => uint256) internal _marketNetStake;
+
+    /// @notice Per-market/per-selection net stake (post-fee). Incremented
+    ///         on every bet; subtracted from `_marketNetStake` on resolution
+    ///         for the winning selection to isolate the losing total.
+    mapping(uint256 => mapping(uint64 => uint256)) internal _selectionNetStake;
+
+    /// @notice Per-match admin-configurable maximum odds (post-4-decimal, e.g.
+    ///         50000 = 5.00x). Softer cap than the hardcoded `MAX_ODDS`. 0 =
+    ///         disabled (uses `MAX_ODDS` as the cap). Gives operators a knob
+    ///         to tighten exposure per sport / per deployment without upgrade.
+    uint32 public maxAllowedOdds;
+
     // ═══════════════════════════════════════════════════════════════════════
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════
@@ -154,6 +171,7 @@ abstract contract BettingMatch is
     event Refund(uint256 indexed marketId, address indexed user, uint256 betIndex, uint256 amount);
     event USDCTokenSet(address indexed token);
     event LiquidityPoolSet(address indexed pool);
+    event MaxAllowedOddsSet(uint32 oldMax, uint32 newMax);
 
     // ═══════════════════════════════════════════════════════════════════════
     // CUSTOM ERRORS
@@ -289,10 +307,28 @@ abstract contract BettingMatch is
         return _oddsRegistries[marketId].values[oddsIndex - 1];
     }
 
-    function _validateOdds(uint32 odds) internal pure {
-        if (odds < MIN_ODDS || odds > MAX_ODDS) {
-            revert InvalidOddsValue(odds, MIN_ODDS, MAX_ODDS);
+    /// @dev Validates odds against (a) the hardcoded MIN/MAX boundary and
+    ///      (b) the softer admin-configurable `maxAllowedOdds` (when non-zero).
+    ///      Operational defence against fat-finger odds updates by the backend
+    ///      odds-setter key.
+    function _validateOdds(uint32 odds) internal view {
+        uint32 softCap = maxAllowedOdds;
+        uint32 effectiveMax = softCap == 0 ? MAX_ODDS : softCap;
+        if (odds < MIN_ODDS || odds > effectiveMax) {
+            revert InvalidOddsValue(odds, MIN_ODDS, effectiveMax);
         }
+    }
+
+    /// @notice Admin setter for the per-match soft odds cap.
+    /// @dev    Must be 0 (disabled) or within [MIN_ODDS, MAX_ODDS]. Takes
+    ///         effect for all future `setMarketOdds` calls; does NOT
+    ///         retroactively invalidate bets at odds > new cap.
+    function setMaxAllowedOdds(uint32 newMax) external onlyRole(ADMIN_ROLE) {
+        if (newMax != 0 && (newMax < MIN_ODDS || newMax > MAX_ODDS)) {
+            revert InvalidOddsValue(newMax, MIN_ODDS, MAX_ODDS);
+        }
+        emit MaxAllowedOddsSet(maxAllowedOdds, newMax);
+        maxAllowedOdds = newMax;
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -444,6 +480,8 @@ abstract contract BettingMatch is
         _selectionLiabilities[marketId][selection]   += potentialPayout;
         _marketNetExposure[marketId]                 += netExposure;
         _selectionNetExposures[marketId][selection]  += netExposure;
+        _marketNetStake[marketId]                    += netStake;
+        _selectionNetStake[marketId][selection]      += netStake;
 
         // Pool-side bookkeeping + solvency / cap enforcement. Reverts here
         // cascade to the user; their USDC transfer is also reverted atomically.
@@ -462,9 +500,10 @@ abstract contract BettingMatch is
 
     /// @notice Resolve a market with the final result.
     /// @dev    Releases every losing selection's reserved net exposure on the
-    ///         pool. Winning-side reservations stay until each winner claims.
-    ///         Net-exposure bookkeeping parallels the payout bookkeeping but
-    ///         is what the pool actually tracks (= `payout - stake`).
+    ///         pool AND signals the losing net-stake total so the pool can
+    ///         accrue the treasury's 50% share. Winning-side reservations
+    ///         stay until each winner claims. Net-exposure bookkeeping
+    ///         parallels the payout bookkeeping (= `payout - stake`).
     function resolveMarket(uint256 marketId, uint64 result)
         external
         validMarket(marketId)
@@ -484,11 +523,18 @@ abstract contract BettingMatch is
             _marketNetExposure[marketId] - _selectionNetExposures[marketId][result];
         uint256 losingPayout =
             _marketLiabilities[marketId] - _selectionLiabilities[marketId][result];
+        uint256 losingNetStake =
+            _marketNetStake[marketId] - _selectionNetStake[marketId][result];
 
         _marketNetExposure[marketId] -= losingNetExposure;
         _marketLiabilities[marketId] -= losingPayout;
 
-        liquidityPool.settleMarket(address(this), marketId, losingNetExposure);
+        liquidityPool.settleMarket(
+            address(this),
+            marketId,
+            losingNetExposure,
+            losingNetStake
+        );
 
         emit MarketResolved(marketId, result, core.resolvedAt);
     }
@@ -727,6 +773,9 @@ abstract contract BettingMatch is
     //  10. _selectionLiabilities (mapping)
     //  11. _marketNetExposure (mapping)
     //  12. _selectionNetExposures (mapping)
-    // 12 named slots + 38 gap = 50 total (OZ upgradeable convention).
-    uint256[38] private __gap;
+    //  13. _marketNetStake (mapping)
+    //  14. _selectionNetStake (mapping)
+    //  15. maxAllowedOdds (uint32)
+    // 15 named slots + 35 gap = 50 total (OZ upgradeable convention).
+    uint256[35] private __gap;
 }

--- a/chiliz-tv/src/interfaces/ILiquidityPool.sol
+++ b/chiliz-tv/src/interfaces/ILiquidityPool.sol
@@ -16,7 +16,8 @@ interface ILiquidityPool {
     /// @notice Record a bet that has already been funded to the pool.
     /// @dev    Caller MUST have transferred `netStake` USDC to the pool
     ///         before calling. Caller must hold `MATCH_ROLE` or `ROUTER_ROLE`.
-    ///         Reverts on cap breach or insufficient free balance.
+    ///         Reverts on cap breach, insufficient free balance, or breach
+    ///         of the pool-wide `maxBetAmount` (if set).
     function recordBet(
         address bettingMatch,
         uint256 marketId,
@@ -25,12 +26,18 @@ interface ILiquidityPool {
         uint256 netExposure
     ) external;
 
-    /// @notice Release losing-side liability when a market resolves.
+    /// @notice Release losing-side liability AND accrue the treasury's share
+    ///         of the losing stakes at market resolution.
     /// @dev    Called by the match contract during `resolveMarket`.
+    ///         `losingNetStake` is the sum of post-fee stakes on all losing
+    ///         selections. 50% of this amount (`TREASURY_SHARE_BPS`) accrues
+    ///         as a pull-based claim for the treasury; the remaining 50%
+    ///         stays in the pool and compounds into LP NAV.
     function settleMarket(
         address bettingMatch,
         uint256 marketId,
-        uint256 losingLiabilityToRelease
+        uint256 losingLiabilityToRelease,
+        uint256 losingNetStake
     ) external;
 
     /// @notice Pay a winner. Transfers `payout` USDC and releases the bet's
@@ -59,18 +66,71 @@ interface ILiquidityPool {
     ) external;
 
     // -----------------------------------------------------------------------
-    // Governance / view
+    // Treasury rotation (2-step) and withdrawal (pull-based)
+    // -----------------------------------------------------------------------
+
+    /// @notice Propose a new treasury address. Only callable by the current
+    ///         treasury. Rotation completes when the pending address calls
+    ///         `acceptTreasury()`.
+    function proposeTreasury(address newTreasury) external;
+
+    /// @notice Cancel a pending treasury proposal. Only callable by the
+    ///         current treasury.
+    function cancelTreasuryProposal() external;
+
+    /// @notice Accept the pending treasury role. Must be called from the
+    ///         address set via `proposeTreasury`. Completes the rotation.
+    function acceptTreasury() external;
+
+    /// @notice Withdraw `amount` of accrued treasury balance in USDC.
+    /// @dev    Only callable by the current treasury. Funds always go to
+    ///         `treasury`. Reverts if `amount` exceeds either the accrued
+    ///         balance or the pool's free (non-bet-liability) balance.
+    function withdrawTreasury(uint256 amount) external;
+
+    // -----------------------------------------------------------------------
+    // Admin (DEFAULT_ADMIN_ROLE-gated)
+    // -----------------------------------------------------------------------
+
+    /// @notice Set a pool-wide maximum per-bet netStake. 0 = disabled.
+    function setMaxBetAmount(uint256 newMax) external;
+
+    // -----------------------------------------------------------------------
+    // Views
     // -----------------------------------------------------------------------
 
     /// @notice Configured protocol fee in basis points (stake skim at placement).
     function protocolFeeBps() external view returns (uint16);
 
-    /// @notice Address receiving protocol fees (NOT LP capital).
+    /// @notice Address receiving protocol fees and holding withdrawal rights
+    ///         over accrued treasury balance.
     function treasury() external view returns (address);
 
-    /// @notice USDC not currently reserved for potential winners.
+    /// @notice Pending treasury in a 2-step rotation (0 = none pending).
+    function pendingTreasury() external view returns (address);
+
+    /// @notice Treasury's accrued USDC claim against the pool. Physically
+    ///         held inside the pool contract; withdrawable via
+    ///         `withdrawTreasury`.
+    function accruedTreasury() external view returns (uint256);
+
+    /// @notice Amount of USDC the treasury can withdraw RIGHT NOW. Equal to
+    ///         `min(accruedTreasury, USDC.balance - totalLiabilities)` —
+    ///         i.e. capped so a withdrawal can never starve live bet payouts.
+    function treasuryWithdrawable() external view returns (uint256);
+
+    /// @notice USDC not currently reserved for potential winners or treasury
+    ///         accrual. Same value as ERC-4626 `totalAssets()`.
     function freeBalance() external view returns (uint256);
 
     /// @notice Global sum of reserved winning-side liabilities.
     function totalLiabilities() external view returns (uint256);
+
+    /// @notice Pool utilization in basis points:
+    ///         `totalLiabilities * 10_000 / totalAssets()`. Capped at
+    ///         `type(uint16).max` to avoid overflow when totalAssets → 0.
+    function utilization() external view returns (uint16);
+
+    /// @notice Pool-wide maximum per-bet netStake (0 = disabled).
+    function maxBetAmount() external view returns (uint256);
 }

--- a/chiliz-tv/src/liquidity/LiquidityPool.sol
+++ b/chiliz-tv/src/liquidity/LiquidityPool.sol
@@ -20,18 +20,37 @@ import {ILiquidityPool} from "../interfaces/ILiquidityPool.sol";
 
 /// @title LiquidityPool
 /// @notice ChilizTV's single source of bet liquidity. LPs deposit USDC and
-///         receive transferable ERC-4626 shares that auto-compound the house
-///         edge priced into fixed odds. All bet stakes enter this contract;
-///         `BettingMatch` proxies hold no USDC.
-/// @dev    NAV model: `totalAssets() = USDC.balanceOf(this) - totalLiabilities`.
-///         Withdrawals are gated on `freeBalance` (unreserved USDC) and a
+///         receive transferable ERC-4626 shares that auto-compound half of
+///         every losing stake as house edge. The other half of each losing
+///         stake accrues to the treasury as a pull-based USDC claim.
+/// @dev    NAV model:
+///             totalAssets() = USDC.balanceOf(this)
+///                           - totalLiabilities
+///                           - accruedTreasury
+///
+///         Three distinct claims on the contract's USDC balance:
+///         (1) `totalLiabilities`  — owed to winning bettors (senior, hard reserve).
+///         (2) `accruedTreasury`   — owed to treasury (pull via `withdrawTreasury`).
+///         (3) LP NAV              — residual, priced into ctvLP shares.
+///
+///         Withdrawals are gated on `freeBalance` (= LP NAV) and a
 ///         per-depositor cooldown to prevent flash-NAV manipulation.
 ///
+///         Inflation-attack defence: `_decimalsOffset()` returns 6, which
+///         mirrors USDC's 6 decimals and gives ctvLP 12 effective decimals.
+///         OZ 5.x maps this into virtual shares/assets inside the conversion
+///         math, making the classic first-depositor attack uneconomic.
+///
 ///         Roles:
-///         - DEFAULT_ADMIN_ROLE: Safe multisig. Controls setters and upgrades.
-///         - MATCH_ROLE:        one per authorized BettingMatch proxy.
-///         - ROUTER_ROLE:       ChilizSwapRouter.
-///         - PAUSER_ROLE:       emergency stop.
+///         - DEFAULT_ADMIN_ROLE: Admin key (operational setters + upgrades).
+///                               NOT the treasury — separation is enforced.
+///         - MATCH_ROLE:         one per authorized BettingMatch proxy.
+///         - ROUTER_ROLE:        ChilizSwapRouter.
+///         - PAUSER_ROLE:        emergency stop.
+///         - `treasury` address: the ONLY address that can (a) rotate
+///                               treasury via 2-step `proposeTreasury` /
+///                               `acceptTreasury`, and (b) pull accrued
+///                               funds via `withdrawTreasury`.
 contract LiquidityPool is
     Initializable,
     ERC4626Upgradeable,
@@ -58,6 +77,10 @@ contract LiquidityPool is
 
     /// @notice Upper bound for configurable fees and caps (10%).
     uint16 public constant MAX_BPS_SETTABLE = 1_000;
+
+    /// @notice Treasury's share of every losing stake (50%). Fixed by design —
+    ///         the remaining 50% stays in the pool as LP NAV yield.
+    uint16 public constant TREASURY_SHARE_BPS = 5_000;
 
     // ═══════════════════════════════════════════════════════════════════════
     // STORAGE
@@ -93,9 +116,23 @@ contract LiquidityPool is
     ///         most recent exposure window for that address.
     mapping(address holder => uint48) public lastDepositAt;
 
-    /// @dev Reserved for upgrades. Size chosen to pad the structure to a
-    ///      predictable 50-slot footprint.
-    uint256[43] private __gap;
+    /// @notice Treasury's accrued USDC claim. Physically held inside this
+    ///         contract; pullable by `treasury` via `withdrawTreasury`.
+    ///         Excluded from `totalAssets()` so LP shares do not reflect
+    ///         funds earmarked for the treasury.
+    uint256 public accruedTreasury;
+
+    /// @notice Pending treasury address in a 2-step rotation. Cleared on
+    ///         `acceptTreasury()` or `cancelTreasuryProposal()`.
+    address public pendingTreasury;
+
+    /// @notice Pool-wide per-bet cap in USDC (6 decimals). 0 = disabled.
+    ///         Checked on every `recordBet` against `netStake` (post-fee).
+    uint256 public maxBetAmount;
+
+    /// @dev Reserved for upgrades. Shrunk from 43 → 40 after appending three
+    ///      new storage slots above. Do NOT reorder or delete named slots.
+    uint256[40] private __gap;
 
     // ═══════════════════════════════════════════════════════════════════════
     // EVENTS
@@ -103,10 +140,20 @@ contract LiquidityPool is
 
     event MatchAuthorized(address indexed bettingMatch);
     event MatchRevoked(address indexed bettingMatch);
-    event TreasurySet(address indexed oldTreasury, address indexed newTreasury);
+    event TreasuryProposed(address indexed proposer, address indexed pending);
+    event TreasuryProposalCancelled(address indexed pending);
+    event TreasuryAccepted(address indexed oldTreasury, address indexed newTreasury);
+    event TreasuryWithdrawn(address indexed to, uint256 amount);
+    event TreasuryAccrued(
+        address indexed bettingMatch,
+        uint256 indexed marketId,
+        uint256 losingNetStake,
+        uint256 treasuryShare
+    );
     event ProtocolFeeSet(uint16 oldBps, uint16 newBps);
     event MaxLiabilityPerMarketSet(uint16 oldBps, uint16 newBps);
     event MaxLiabilityPerMatchSet(uint16 oldBps, uint16 newBps);
+    event MaxBetAmountSet(uint256 oldMax, uint256 newMax);
     event DepositCooldownSet(uint48 oldSeconds, uint48 newSeconds);
     event BetRecorded(
         address indexed bettingMatch,
@@ -147,6 +194,11 @@ contract LiquidityPool is
     error MarketLiabilityCapExceeded(uint256 requested, uint256 cap);
     error MatchLiabilityCapExceeded(uint256 requested, uint256 cap);
     error LiabilityUnderflow();
+    error BetAmountAboveCap(uint256 requested, uint256 cap);
+    error NotTreasury(address caller, address treasury);
+    error NotPendingTreasury(address caller, address pending);
+    error NoPendingTreasury();
+    error InsufficientTreasuryBalance(uint256 requested, uint256 available);
 
     // ═══════════════════════════════════════════════════════════════════════
     // INITIALIZER
@@ -159,8 +211,12 @@ contract LiquidityPool is
 
     /// @notice One-shot initializer for the UUPS proxy.
     /// @param usdc_            USDC token address (asset).
-    /// @param admin_           DEFAULT_ADMIN_ROLE + PAUSER_ROLE recipient (Safe).
-    /// @param treasury_        Protocol fee recipient.
+    /// @param admin_           DEFAULT_ADMIN_ROLE + PAUSER_ROLE recipient.
+    ///                         MUST be distinct from `treasury_` — the admin
+    ///                         key cannot redirect accrued treasury funds.
+    /// @param treasury_        Initial treasury address (Safe multisig). Sole
+    ///                         controller of treasury rotation and accrued
+    ///                         balance withdrawals.
     /// @param protocolFeeBps_  Initial protocol fee (<= MAX_BPS_SETTABLE).
     /// @param maxMarketBps_    Initial per-market cap in bps.
     /// @param maxMatchBps_     Initial per-match cap in bps.
@@ -197,7 +253,7 @@ contract LiquidityPool is
         maxLiabilityPerMatchBps  = maxMatchBps_;
         depositCooldownSeconds   = cooldown_;
 
-        emit TreasurySet(address(0), treasury_);
+        emit TreasuryAccepted(address(0), treasury_);
         emit ProtocolFeeSet(0, protocolFeeBps_);
         emit MaxLiabilityPerMarketSet(0, maxMarketBps_);
         emit MaxLiabilityPerMatchSet(0, maxMatchBps_);
@@ -208,17 +264,55 @@ contract LiquidityPool is
     // ERC-4626 OVERRIDES
     // ═══════════════════════════════════════════════════════════════════════
 
-    /// @notice Assets backing LP shares = USDC balance minus reserved winner liabilities.
+    /// @notice Assets backing LP shares.
+    /// @dev    = USDC.balanceOf(this) − totalLiabilities − accruedTreasury.
+    ///         Subtracting `accruedTreasury` is the critical invariant that
+    ///         keeps LP NAV from double-counting the treasury's share of
+    ///         losing stakes. Clamped to 0 to stay safe if a parameter
+    ///         misconfiguration or rounding leaves the pool temporarily
+    ///         underwater.
     function totalAssets() public view override returns (uint256) {
-        uint256 bal = IERC20(asset()).balanceOf(address(this));
-        return bal > totalLiabilities ? bal - totalLiabilities : 0;
+        uint256 bal      = IERC20(asset()).balanceOf(address(this));
+        uint256 reserved = totalLiabilities + accruedTreasury;
+        return bal > reserved ? bal - reserved : 0;
     }
 
-    /// @notice USDC not reserved for potential winners. Same value as
-    ///         `totalAssets()` in this design; kept as a distinct symbol for
-    ///         readability in revert messages and integration code.
+    /// @notice USDC that LPs can collectively withdraw right now (same as
+    ///         `totalAssets()`). Exposed as a named symbol so integrations
+    ///         and dashboards have a stable, unambiguous endpoint.
     function freeBalance() public view returns (uint256) {
         return totalAssets();
+    }
+
+    /// @notice Pool utilization in basis points: reserved bet liabilities
+    ///         as a share of LP NAV.
+    /// @dev    `totalLiabilities * 10_000 / totalAssets()`. Returns
+    ///         `type(uint16).max` if `totalAssets()` is 0 (fully utilized)
+    ///         to avoid division-by-zero surprises in off-chain consumers.
+    function utilization() public view returns (uint16) {
+        uint256 assets = totalAssets();
+        if (assets == 0) return totalLiabilities == 0 ? 0 : type(uint16).max;
+        uint256 ratio = (totalLiabilities * BPS_DENOMINATOR) / assets;
+        return ratio > type(uint16).max ? type(uint16).max : uint16(ratio);
+    }
+
+    /// @notice Treasury's currently withdrawable balance. Capped so that
+    ///         pulling it can never starve outstanding bet payouts.
+    function treasuryWithdrawable() public view returns (uint256) {
+        uint256 accrued = accruedTreasury;
+        uint256 bal     = IERC20(asset()).balanceOf(address(this));
+        uint256 floor   = totalLiabilities;
+        uint256 unreserved = bal > floor ? bal - floor : 0;
+        return accrued < unreserved ? accrued : unreserved;
+    }
+
+    /// @dev ERC-4626 inflation-attack mitigation (OZ 5.x). A non-zero offset
+    ///      multiplies share supply by `10 ** offset`, so the cost to mount
+    ///      the first-depositor attack grows by the same factor. 6 mirrors
+    ///      USDC's decimals and pushes the attack cost well past economic
+    ///      viability without burdening normal deposits.
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return 6;
     }
 
     /// @inheritdoc ERC4626Upgradeable
@@ -322,6 +416,14 @@ contract LiquidityPool is
         _;
     }
 
+    /// @dev Treasury address is the ONLY authority for treasury rotation
+    ///      and accrued-balance withdrawals. Explicitly disjoint from
+    ///      DEFAULT_ADMIN_ROLE — admin compromise cannot touch funds.
+    modifier onlyTreasury() {
+        if (msg.sender != treasury) revert NotTreasury(msg.sender, treasury);
+        _;
+    }
+
     /// @inheritdoc ILiquidityPool
     function recordBet(
         address bettingMatch,
@@ -333,6 +435,11 @@ contract LiquidityPool is
         if (bettingMatch == address(0) || bettor == address(0)) revert ZeroAddress();
         if (netStake == 0) revert ZeroAmount();
         if (!hasRole(MATCH_ROLE, bettingMatch)) revert MatchNotAuthorized(bettingMatch);
+
+        // Pool-wide per-bet cap (if configured). Checked against the
+        // post-fee netStake — that's the amount actually exposed to pool risk.
+        uint256 betCap = maxBetAmount;
+        if (betCap != 0 && netStake > betCap) revert BetAmountAboveCap(netStake, betCap);
 
         // netExposure == 0 is legal (1.0000x odds — boundary case). Still enforce
         // caps so a zero-exposure bet can still breach global solvency in edge
@@ -359,24 +466,37 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPool
+    /// @dev Two-part settlement in one call:
+    ///      1. Release the losing-side reserved liability (bets that won't
+    ///         pay out).
+    ///      2. Accrue `TREASURY_SHARE_BPS` (50%) of the losing net-stake
+    ///         total to the treasury as a pull-based claim. The remaining
+    ///         half stays in the USDC balance and compounds into LP NAV
+    ///         automatically (since totalAssets tracks balance − liabilities
+    ///         − accruedTreasury).
     function settleMarket(
         address bettingMatch,
         uint256 marketId,
-        uint256 losingLiabilityToRelease
+        uint256 losingLiabilityToRelease,
+        uint256 losingNetStake
     ) external override whenNotPaused nonReentrant onlyMatch {
-        if (losingLiabilityToRelease == 0) {
-            emit MarketSettled(bettingMatch, marketId, 0);
-            return;
+        uint256 actualReleased;
+        if (losingLiabilityToRelease > 0) {
+            uint256 m = marketLiability[bettingMatch][marketId];
+            actualReleased = losingLiabilityToRelease > m ? m : losingLiabilityToRelease;
+            marketLiability[bettingMatch][marketId] = m - actualReleased;
+            matchLiability[bettingMatch]            = _safeSub(matchLiability[bettingMatch], actualReleased);
+            totalLiabilities                        = _safeSub(totalLiabilities, actualReleased);
         }
+        emit MarketSettled(bettingMatch, marketId, actualReleased);
 
-        uint256 m = marketLiability[bettingMatch][marketId];
-        uint256 actual = losingLiabilityToRelease > m ? m : losingLiabilityToRelease;
-
-        marketLiability[bettingMatch][marketId] = m - actual;
-        matchLiability[bettingMatch]            = _safeSub(matchLiability[bettingMatch], actual);
-        totalLiabilities                        = _safeSub(totalLiabilities, actual);
-
-        emit MarketSettled(bettingMatch, marketId, actual);
+        if (losingNetStake > 0) {
+            uint256 share = (losingNetStake * TREASURY_SHARE_BPS) / BPS_DENOMINATOR;
+            if (share > 0) {
+                accruedTreasury += share;
+                emit TreasuryAccrued(bettingMatch, marketId, losingNetStake, share);
+            }
+        }
     }
 
     /// @inheritdoc ILiquidityPool
@@ -450,12 +570,6 @@ contract LiquidityPool is
         emit MatchRevoked(bettingMatch);
     }
 
-    function setTreasury(address newTreasury) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (newTreasury == address(0)) revert ZeroAddress();
-        emit TreasurySet(treasury, newTreasury);
-        treasury = newTreasury;
-    }
-
     function setProtocolFeeBps(uint16 newBps) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newBps > MAX_BPS_SETTABLE) revert BpsOutOfRange(newBps, MAX_BPS_SETTABLE);
         emit ProtocolFeeSet(protocolFeeBps, newBps);
@@ -479,10 +593,75 @@ contract LiquidityPool is
         depositCooldownSeconds = newSeconds;
     }
 
+    /// @notice Set the pool-wide per-bet cap. 0 disables the check.
+    /// @dev    Admin-configurable. Applied to post-fee `netStake` on every
+    ///         `recordBet`; does NOT retroactively affect existing bets.
+    function setMaxBetAmount(uint256 newMax) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit MaxBetAmountSet(maxBetAmount, newMax);
+        maxBetAmount = newMax;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // TREASURY ROTATION (2-step, onlyTreasury)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice Propose a new treasury address. Admin CANNOT call this —
+    ///         rotation rights belong exclusively to the current treasury.
+    function proposeTreasury(address newTreasury) external onlyTreasury {
+        if (newTreasury == address(0)) revert ZeroAddress();
+        pendingTreasury = newTreasury;
+        emit TreasuryProposed(msg.sender, newTreasury);
+    }
+
+    /// @notice Cancel a pending treasury proposal.
+    function cancelTreasuryProposal() external onlyTreasury {
+        address pending = pendingTreasury;
+        if (pending == address(0)) revert NoPendingTreasury();
+        pendingTreasury = address(0);
+        emit TreasuryProposalCancelled(pending);
+    }
+
+    /// @notice Accept the treasury role. Must be called from the address
+    ///         set via `proposeTreasury` — proves the new address is live
+    ///         before handing over withdrawal rights.
+    function acceptTreasury() external {
+        address pending = pendingTreasury;
+        if (pending == address(0)) revert NoPendingTreasury();
+        if (msg.sender != pending) revert NotPendingTreasury(msg.sender, pending);
+        address old = treasury;
+        treasury = pending;
+        pendingTreasury = address(0);
+        emit TreasuryAccepted(old, pending);
+    }
+
+    /// @notice Pull `amount` of accrued USDC to the treasury address.
+    /// @dev    Only callable by the current treasury. Funds always go to
+    ///         `treasury` (no `to` parameter — the Safe pulls to itself).
+    ///         Bounded by `treasuryWithdrawable()` so outstanding bet
+    ///         payouts are never starved.
+    function withdrawTreasury(uint256 amount)
+        external
+        onlyTreasury
+        whenNotPaused
+        nonReentrant
+    {
+        if (amount == 0) revert ZeroAmount();
+        uint256 available = treasuryWithdrawable();
+        if (amount > available) revert InsufficientTreasuryBalance(amount, available);
+
+        // CEI: update state before external transfer.
+        accruedTreasury -= amount;
+
+        address to = treasury;
+        SafeERC20.safeTransfer(IERC20(asset()), to, amount);
+        emit TreasuryWithdrawn(to, amount);
+    }
+
     function pause()   external onlyRole(PAUSER_ROLE)        { _pause(); }
     function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) { _unpause(); }
 
-    /// @dev UUPS upgrade authorization — restricted to Safe.
+    /// @dev UUPS upgrade authorization — gated to the admin key (which is
+    ///      disjoint from `treasury` by design).
     function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/chiliz-tv/test/LiquidityPoolInvariantTest.t.sol
+++ b/chiliz-tv/test/LiquidityPoolInvariantTest.t.sol
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {Test, console} from "forge-std/Test.sol";
+import {FootballMatch} from "../src/betting/FootballMatch.sol";
+import {LiquidityPool} from "../src/liquidity/LiquidityPool.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {MockUSDC} from "./mocks/MockUSDC.sol";
+
+/// @title LiquidityPoolHandler
+/// @notice Randomized action wrapper for the Foundry invariant runner. Each
+///         external function represents one "unit of time" — the runner picks
+///         functions and args at random, and we verify the pool's accounting
+///         invariants hold after every sequence.
+///
+///         Design choice: each bet is wrapped in a self-contained
+///         place→close→resolve or place→close→resolve→claim flow so the
+///         handler never has to track open market lifecycles across calls.
+///         This keeps the state space small and focuses the runner on the
+///         money-flow invariants (solvency, accrual monotonicity, NAV).
+contract LiquidityPoolHandler is Test {
+    LiquidityPool public pool;
+    FootballMatch public match_;
+    MockUSDC      public usdc;
+
+    address public admin;
+    address public treasury;
+    address public resolver;
+
+    address[] internal lps;
+    address[] internal bettors;
+
+    // Ghost bookkeeping
+    uint256 public ghostMaxAccruedSeen;
+    uint256 public ghostTotalTreasuryWithdrawn;
+
+    bytes32 constant MARKET_WINNER = keccak256("WINNER");
+
+    constructor(
+        LiquidityPool _pool,
+        FootballMatch _match,
+        MockUSDC      _usdc,
+        address _admin,
+        address _treasury,
+        address _resolver,
+        address[] memory _lps,
+        address[] memory _bettors
+    ) {
+        pool     = _pool;
+        match_   = _match;
+        usdc     = _usdc;
+        admin    = _admin;
+        treasury = _treasury;
+        resolver = _resolver;
+
+        for (uint256 i = 0; i < _lps.length; i++)     lps.push(_lps[i]);
+        for (uint256 i = 0; i < _bettors.length; i++) bettors.push(_bettors[i]);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ACTIONS (called by the invariant runner)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function deposit(uint256 lpIdx, uint256 amountRaw) external {
+        address lp = lps[lpIdx % lps.length];
+        uint256 balance = usdc.balanceOf(lp);
+        if (balance == 0) return;
+        uint256 amount = bound(amountRaw, 1e6, balance);
+
+        vm.startPrank(lp);
+        usdc.approve(address(pool), amount);
+        pool.deposit(amount, lp);
+        vm.stopPrank();
+        _refreshAccruedGhost();
+    }
+
+    function withdrawMax(uint256 lpIdx) external {
+        address lp = lps[lpIdx % lps.length];
+        uint256 cap = pool.maxWithdraw(lp);
+        if (cap == 0) return;
+        vm.prank(lp);
+        pool.withdraw(cap, lp, lp);
+        _refreshAccruedGhost();
+    }
+
+    function betAndLose(uint256 bettorIdx, uint256 stakeRaw, uint32 oddsRaw) external {
+        address bettor = bettors[bettorIdx % bettors.length];
+        uint256 bal = usdc.balanceOf(bettor);
+        if (bal < 10e6) return;
+        uint32 odds = uint32(bound(uint256(oddsRaw), 11_000, 50_000)); // 1.10x – 5.00x
+
+        uint256 stake = bound(stakeRaw, 1e6, bal);
+        uint256 free = pool.freeBalance();
+        // netExposure = stake × (odds-10000)/10000. Cap stake so netExposure ≤ half of free.
+        uint256 maxStake = (free * 10_000) / (2 * uint256(odds - 10_000));
+        if (maxStake < 1e6) return;
+        if (stake > maxStake) stake = maxStake;
+        if (stake < 1e6) return;
+
+        uint256 marketId = _newMarket(odds);
+        _placeBet(bettor, marketId, 0, stake);
+        _closeAndResolve(marketId, 1); // selection 0 loses
+        _refreshAccruedGhost();
+    }
+
+    function betAndWinThenClaim(uint256 bettorIdx, uint256 stakeRaw, uint32 oddsRaw) external {
+        address bettor = bettors[bettorIdx % bettors.length];
+        uint256 bal = usdc.balanceOf(bettor);
+        if (bal < 10e6) return;
+        uint32 odds = uint32(bound(uint256(oddsRaw), 11_000, 50_000));
+
+        uint256 stake = bound(stakeRaw, 1e6, bal);
+        uint256 free = pool.freeBalance();
+        uint256 maxStake = (free * 10_000) / (2 * uint256(odds - 10_000));
+        if (maxStake < 1e6) return;
+        if (stake > maxStake) stake = maxStake;
+        if (stake < 1e6) return;
+
+        uint256 marketId = _newMarket(odds);
+        _placeBet(bettor, marketId, 0, stake);
+        _closeAndResolve(marketId, 0); // selection 0 wins
+
+        // Claim — may revert if pool lacks free USDC for payout; safe to
+        // swallow since that's itself an invariant test: a winner can't be
+        // paid if the pool is insolvent, but that would also imply the
+        // invariants are violated elsewhere.
+        vm.prank(bettor);
+        try match_.claim(marketId, 0) {} catch {}
+        _refreshAccruedGhost();
+    }
+
+    function treasuryWithdrawMax() external {
+        uint256 avail = pool.treasuryWithdrawable();
+        if (avail == 0) return;
+        vm.prank(treasury);
+        pool.withdrawTreasury(avail);
+        ghostTotalTreasuryWithdrawn += avail;
+        _refreshAccruedGhost();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _newMarket(uint32 odds) internal returns (uint256 marketId) {
+        vm.prank(admin);
+        match_.addMarketWithLine(MARKET_WINNER, odds, 0);
+        marketId = match_.marketCount() - 1;
+        vm.prank(admin);
+        match_.openMarket(marketId);
+    }
+
+    function _placeBet(address user, uint256 marketId, uint64 selection, uint256 amount) internal {
+        vm.startPrank(user);
+        usdc.approve(address(match_), amount);
+        match_.placeBetUSDC(marketId, selection, amount);
+        vm.stopPrank();
+    }
+
+    function _closeAndResolve(uint256 marketId, uint64 result) internal {
+        vm.prank(admin);
+        match_.closeMarket(marketId);
+        vm.prank(resolver);
+        match_.resolveMarket(marketId, result);
+    }
+
+    function _refreshAccruedGhost() internal {
+        uint256 current = pool.accruedTreasury();
+        if (current > ghostMaxAccruedSeen) ghostMaxAccruedSeen = current;
+    }
+}
+
+/// @title LiquidityPoolInvariantTest
+/// @notice Foundry invariant runner for the money-flow invariants.
+///
+///         Invariants checked after every randomized action sequence:
+///         (I1)  Solvency: USDC.balance >= totalLiabilities + accruedTreasury
+///         (I2)  NAV identity: totalAssets() == USDC.balance − totalLiabilities − accruedTreasury
+///         (I3)  Treasury pull-only monotonicity: accruedTreasury is
+///                either unchanged or rising, UNLESS a treasury withdrawal
+///                happened (tracked via ghostTotalTreasuryWithdrawn).
+///         (I4)  Admin cannot drain the pool: the admin key never holds
+///                `treasury` authority.
+///         (I5)  Share price floor: if no winning-bet claim happened, share
+///                price never falls below the initial mint ratio. (Enforced
+///                indirectly — we only assert that totalAssets ≥ 0 and
+///                share conversion is consistent.)
+contract LiquidityPoolInvariantTest is Test {
+    LiquidityPool public pool;
+    FootballMatch public match_;
+    MockUSDC      public usdc;
+    LiquidityPoolHandler public handler;
+
+    address internal admin    = address(0xA11CE);
+    address internal treasury = address(0xB0B);
+    address internal resolver = address(0xBEEF);
+
+    bytes32 constant ODDS_SETTER_ROLE = keccak256("ODDS_SETTER_ROLE");
+    bytes32 constant RESOLVER_ROLE    = keccak256("RESOLVER_ROLE");
+
+    function setUp() public {
+        usdc = new MockUSDC();
+
+        LiquidityPool poolImpl = new LiquidityPool();
+        bytes memory poolInit = abi.encodeWithSelector(
+            LiquidityPool.initialize.selector,
+            address(usdc),
+            admin,
+            treasury,
+            uint16(200),    // 2% protocol fee
+            uint16(5000),   // 50% per-market cap (loose — handler guards for free balance)
+            uint16(9000),   // 90% per-match cap
+            uint48(0)       // no cooldown (simplifies invariants)
+        );
+        pool = LiquidityPool(address(new ERC1967Proxy(address(poolImpl), poolInit)));
+
+        FootballMatch matchImpl = new FootballMatch();
+        bytes memory matchInit = abi.encodeWithSelector(
+            FootballMatch.initialize.selector,
+            "Invariant Match",
+            admin
+        );
+        match_ = FootballMatch(payable(address(new ERC1967Proxy(address(matchImpl), matchInit))));
+
+        vm.startPrank(admin);
+        match_.grantRole(ODDS_SETTER_ROLE, admin);
+        match_.grantRole(RESOLVER_ROLE, resolver);
+        match_.setUSDCToken(address(usdc));
+        match_.setLiquidityPool(address(pool));
+        pool.authorizeMatch(address(match_));
+        vm.stopPrank();
+
+        // LPs and bettors
+        address[] memory lps = new address[](3);
+        lps[0] = address(0x1001);
+        lps[1] = address(0x1002);
+        lps[2] = address(0x1003);
+
+        address[] memory bettors = new address[](3);
+        bettors[0] = address(0x2001);
+        bettors[1] = address(0x2002);
+        bettors[2] = address(0x2003);
+
+        for (uint256 i = 0; i < lps.length; i++) usdc.mint(lps[i], 1_000_000e6);
+        for (uint256 i = 0; i < bettors.length; i++) usdc.mint(bettors[i], 1_000_000e6);
+
+        // Seed the pool with initial liquidity so the runner has something to
+        // work with from step 1. Avoids trivial "empty pool" invariants.
+        vm.startPrank(lps[0]);
+        usdc.approve(address(pool), 500_000e6);
+        pool.deposit(500_000e6, lps[0]);
+        vm.stopPrank();
+
+        handler = new LiquidityPoolHandler(
+            pool, match_, usdc,
+            admin, treasury, resolver,
+            lps, bettors
+        );
+
+        // Scope the runner to the handler's external functions only.
+        targetContract(address(handler));
+        bytes4[] memory sels = new bytes4[](5);
+        sels[0] = handler.deposit.selector;
+        sels[1] = handler.withdrawMax.selector;
+        sels[2] = handler.betAndLose.selector;
+        sels[3] = handler.betAndWinThenClaim.selector;
+        sels[4] = handler.treasuryWithdrawMax.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: sels}));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // INVARIANTS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @dev I1 — the pool ALWAYS holds enough USDC to cover reserved bet
+    ///      payouts and the treasury's accrued claim. If this breaks, LP
+    ///      capital is underwater or accounting is drifting.
+    function invariant_Solvency() public view {
+        uint256 bal = usdc.balanceOf(address(pool));
+        uint256 owed = pool.totalLiabilities() + pool.accruedTreasury();
+        assertGe(bal, owed, "pool USDC must cover liabilities + accrued treasury");
+    }
+
+    /// @dev I2 — ERC-4626 NAV identity. `totalAssets()` matches the residual
+    ///      after subtracting senior claims, or is clamped to 0 in the
+    ///      degenerate case (which itself should never happen if I1 holds).
+    function invariant_NAVIdentity() public view {
+        uint256 bal = usdc.balanceOf(address(pool));
+        uint256 owed = pool.totalLiabilities() + pool.accruedTreasury();
+        uint256 expected = bal > owed ? bal - owed : 0;
+        assertEq(pool.totalAssets(), expected, "totalAssets must equal balance - senior claims");
+    }
+
+    /// @dev I3 — treasury claim only decreases via `withdrawTreasury`. The
+    ///      ghost tracks cumulative withdrawals; accrued + withdrawn should
+    ///      always equal the max-seen accrued (modulo settlements that bump
+    ///      it higher, which we also track via ghostMaxAccruedSeen).
+    function invariant_TreasuryMonotonicAccrual() public view {
+        uint256 accrued = pool.accruedTreasury();
+        uint256 withdrawn = handler.ghostTotalTreasuryWithdrawn();
+        // accrued + withdrawn represents all the treasury share ever booked.
+        // That sum must equal the ghostMaxAccruedSeen PLUS any accrual that
+        // happened AFTER a withdrawal lowered the counter. The simpler and
+        // tighter invariant:
+        assertGe(
+            accrued + withdrawn,
+            handler.ghostMaxAccruedSeen(),
+            "accrued+withdrawn cannot decrease vs historical max"
+        );
+    }
+
+    /// @dev I4 — admin cannot impersonate treasury. If admin somehow became
+    ///      `treasury`, the separation is broken and funds are at risk.
+    function invariant_AdminIsNotTreasury() public view {
+        assertTrue(pool.treasury() != admin, "admin key must never equal treasury");
+    }
+
+    /// @dev I5 — treasury withdrawable is never more than the accrued claim.
+    ///      Bounds check on the pull helper itself.
+    function invariant_TreasuryWithdrawableBounded() public view {
+        assertLe(
+            pool.treasuryWithdrawable(),
+            pool.accruedTreasury(),
+            "withdrawable cannot exceed accrued"
+        );
+    }
+}

--- a/chiliz-tv/test/LiquidityPoolV2Test.t.sol
+++ b/chiliz-tv/test/LiquidityPoolV2Test.t.sol
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {Test, console} from "forge-std/Test.sol";
+import {FootballMatch} from "../src/betting/FootballMatch.sol";
+import {BettingMatch} from "../src/betting/BettingMatch.sol";
+import {LiquidityPool} from "../src/liquidity/LiquidityPool.sol";
+import {ILiquidityPool} from "../src/interfaces/ILiquidityPool.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {MockUSDC} from "./mocks/MockUSDC.sol";
+
+/// @title LiquidityPoolV2Test
+/// @notice Tests for the V2 LiquidityPool behaviours introduced alongside the
+///         BettingMatch ↔ LiquidityPool integration:
+///           - 50/50 loss split (LP / accruedTreasury)
+///           - Pull-based `withdrawTreasury` with solvency bound
+///           - 2-step treasury rotation (propose / accept / cancel)
+///           - Admin / treasury role separation
+///           - Pool-wide `maxBetAmount` cap
+///           - `maxAllowedOdds` per-match soft cap
+///           - ERC-4626 inflation-attack mitigation via `_decimalsOffset = 6`
+///           - `utilization()` and `maxWithdraw` gating
+contract LiquidityPoolV2Test is Test {
+    // ────────────────────────── actors ──────────────────────────
+    address internal admin    = address(0xA11CE);
+    address internal treasury = address(0xB0B);
+    address internal newSafe  = address(0xCAFEBABE);
+    address internal oddsSetter = address(0xDEAD);
+    address internal resolver   = address(0xBEEF);
+    address internal lp       = address(0x1111);
+    address internal alice    = address(0x2222);
+    address internal bob      = address(0x3333);
+
+    // ────────────────────────── contracts ───────────────────────
+    MockUSDC      internal usdc;
+    LiquidityPool internal pool;
+    FootballMatch internal footballMatch;
+
+    // ────────────────────────── constants ───────────────────────
+    bytes32 constant ADMIN_ROLE         = keccak256("ADMIN_ROLE");
+    bytes32 constant ODDS_SETTER_ROLE   = keccak256("ODDS_SETTER_ROLE");
+    bytes32 constant RESOLVER_ROLE      = keccak256("RESOLVER_ROLE");
+    bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 constant MARKET_WINNER      = keccak256("WINNER");
+
+    uint32 constant ODDS_PRECISION = 10_000;
+
+    function setUp() public {
+        usdc = new MockUSDC();
+
+        // Pool: admin ≠ treasury (role separation under test)
+        LiquidityPool poolImpl = new LiquidityPool();
+        bytes memory poolInit = abi.encodeWithSelector(
+            LiquidityPool.initialize.selector,
+            address(usdc),
+            admin,
+            treasury,
+            uint16(0),      // protocol fee: 0 for clean math
+            uint16(9000),   // per-market cap: 90%
+            uint16(9500),   // per-match cap: 95%
+            uint48(0)       // cooldown: 0
+        );
+        pool = LiquidityPool(address(new ERC1967Proxy(address(poolImpl), poolInit)));
+
+        // BettingMatch
+        FootballMatch impl = new FootballMatch();
+        bytes memory matchInit = abi.encodeWithSelector(
+            FootballMatch.initialize.selector,
+            "Test Match",
+            admin
+        );
+        footballMatch = FootballMatch(payable(address(new ERC1967Proxy(address(impl), matchInit))));
+
+        vm.startPrank(admin);
+        footballMatch.grantRole(ODDS_SETTER_ROLE, oddsSetter);
+        footballMatch.grantRole(RESOLVER_ROLE, resolver);
+        footballMatch.setUSDCToken(address(usdc));
+        footballMatch.setLiquidityPool(address(pool));
+        pool.authorizeMatch(address(footballMatch));
+        vm.stopPrank();
+
+        // Fund actors
+        usdc.mint(lp,    1_000_000e6);
+        usdc.mint(alice,   100_000e6);
+        usdc.mint(bob,     100_000e6);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ERC-4626 INFLATION-ATTACK MITIGATION
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_DecimalsOffsetPreventsFirstDepositorAttack() public {
+        // OZ 5.x _decimalsOffset = 6 → ctvLP has 12 decimals (USDC 6 + 6).
+        assertEq(pool.decimals(), 12, "ctvLP should have 12 decimals");
+
+        // First depositor receives shares scaled by 10^6 — attacker trying to
+        // inflate share price via 1-wei deposit + direct transfer would need
+        // to commit impractical capital to deflate later depositors' shares.
+        vm.startPrank(lp);
+        usdc.approve(address(pool), 1e6); // 1 USDC
+        uint256 shares = pool.deposit(1e6, lp);
+        vm.stopPrank();
+
+        // With offset = 6: 1 USDC asset → 10^6 × 10^6 = 10^12 shares.
+        assertEq(shares, 1e12, "1 USDC should mint 1e12 shares (offset defends inflation)");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // LOSS SPLIT (50% LP / 50% accrued treasury)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_LossSplit_AccruesHalfToTreasury_HalfToLPs() public {
+        // LP seeds 10,000 USDC → totalAssets 10,000 → shares = 10,000 × 10^6 = 10^10
+        _seedPool(10_000e6);
+        uint256 lpShares = pool.balanceOf(lp);
+        uint256 navBefore = pool.totalAssets();
+        assertEq(navBefore, 10_000e6, "seed NAV");
+
+        // Market: alice bets 100 at 2.00x on selection 0. Resolve selection 1.
+        uint256 marketId = _newMarketAtOdds(20_000);
+        _placeBet(alice, marketId, 0 /* losing */, 100e6);
+
+        vm.prank(admin);
+        footballMatch.closeMarket(marketId);
+        vm.prank(resolver);
+        footballMatch.resolveMarket(marketId, 1 /* alice's bet loses */);
+
+        // Post-resolve expectations:
+        //   accruedTreasury = 50 (50% × 100 losing netStake)
+        //   LP NAV = 10,000 + 50 (the other half of the losing stake)
+        assertEq(pool.accruedTreasury(), 50e6, "treasury accrued 50 USDC");
+        assertEq(pool.totalAssets(), 10_050e6, "LP NAV up by 50 USDC");
+        assertEq(pool.balanceOf(lp), lpShares, "LP shares unchanged");
+
+        // Share price ≈ 1.005 USDC for 1e12 shares (= 1 ctvLP "unit"). Exact
+        // value is 1.005 × 10^6 − 1 wei due to OZ's _decimalsOffset virtual
+        // +1 / +10^offset rounding in convertToAssets.
+        uint256 assetsPerShare = pool.convertToAssets(1e12);
+        assertApproxEqAbs(assetsPerShare, 1_005_000, 1, "share price ~1.005 USDC");
+    }
+
+    function test_LossSplit_NoAccrualWhenAllBetsWin() public {
+        _seedPool(10_000e6);
+
+        uint256 marketId = _newMarketAtOdds(20_000);
+        _placeBet(alice, marketId, 0, 100e6);
+
+        vm.prank(admin);
+        footballMatch.closeMarket(marketId);
+        vm.prank(resolver);
+        footballMatch.resolveMarket(marketId, 0 /* alice wins */);
+
+        assertEq(pool.accruedTreasury(), 0, "no accrual when winner-only market");
+    }
+
+    function test_LossSplit_MixedBetsOnlyAccrueLosingStakes() public {
+        _seedPool(10_000e6);
+
+        uint256 marketId = _newMarketAtOdds(20_000);
+        _placeBet(alice, marketId, 0 /* wins */, 100e6);
+        _placeBet(bob,   marketId, 1 /* loses */, 300e6);
+
+        vm.prank(admin);
+        footballMatch.closeMarket(marketId);
+        vm.prank(resolver);
+        footballMatch.resolveMarket(marketId, 0);
+
+        // Only bob's 300 losing netStake accrues → 150 to treasury.
+        assertEq(pool.accruedTreasury(), 150e6, "accruedTreasury = 50% of losing");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // WITHDRAW TREASURY (pull-based)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_WithdrawTreasury_TransfersToTreasury() public {
+        _accrueTreasury(400e6);
+        uint256 balBefore = usdc.balanceOf(treasury);
+
+        vm.prank(treasury);
+        pool.withdrawTreasury(100e6);
+
+        assertEq(usdc.balanceOf(treasury) - balBefore, 100e6, "treasury received 100 USDC");
+        assertEq(pool.accruedTreasury(), 300e6, "accrued reduced");
+    }
+
+    function test_WithdrawTreasury_RevertsForNonTreasuryCaller() public {
+        _accrueTreasury(400e6);
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LiquidityPool.NotTreasury.selector, admin, treasury
+            )
+        );
+        pool.withdrawTreasury(100e6);
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LiquidityPool.NotTreasury.selector, alice, treasury
+            )
+        );
+        pool.withdrawTreasury(100e6);
+    }
+
+    function test_WithdrawTreasury_RevertsWhenAmountExceedsAccrued() public {
+        _accrueTreasury(400e6);
+
+        vm.prank(treasury);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LiquidityPool.InsufficientTreasuryBalance.selector, 500e6, 400e6
+            )
+        );
+        pool.withdrawTreasury(500e6);
+    }
+
+    function test_WithdrawTreasury_RevertsOnZeroAmount() public {
+        _accrueTreasury(100e6);
+
+        vm.prank(treasury);
+        vm.expectRevert(LiquidityPool.ZeroAmount.selector);
+        pool.withdrawTreasury(0);
+    }
+
+    function test_WithdrawTreasury_DoesNotChangeLPNAV() public {
+        _accrueTreasury(400e6);
+        uint256 navBefore = pool.totalAssets();
+
+        vm.prank(treasury);
+        pool.withdrawTreasury(400e6);
+
+        assertEq(pool.totalAssets(), navBefore, "LP NAV untouched by treasury pull");
+    }
+
+    function test_TreasuryWithdrawable_BoundedByFreeUSDC() public {
+        // Accrue 400. Then create outstanding liabilities that eat into USDC.
+        _accrueTreasury(400e6);
+
+        // Take a huge bet to lock the pool: netExposure grows totalLiabilities.
+        // We'll stop short of actually creating liabilities > USDC, but the
+        // view must correctly cap withdrawable to `USDC − totalLiabilities`.
+        // Simulate by placing a losing-side bet that does NOT resolve — it
+        // keeps liability live.
+        uint256 marketId = _newMarketAtOdds(50_000); // 5.00x
+        // Need a large LP buffer to allow this bet; pool already has seed + accrued funds
+        _placeBet(alice, marketId, 0, 3_000e6); // netExposure = 12_000e6
+        // Don't resolve; liability stays reserved.
+
+        uint256 avail = pool.treasuryWithdrawable();
+        uint256 accrued = pool.accruedTreasury();
+        uint256 bal = usdc.balanceOf(address(pool));
+        uint256 totalLiab = pool.totalLiabilities();
+        uint256 unreserved = bal > totalLiab ? bal - totalLiab : 0;
+        assertEq(avail, accrued < unreserved ? accrued : unreserved, "withdrawable bound");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // TREASURY ROTATION (2-step)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_ProposeTreasury_OnlyCurrentTreasuryCanCall() public {
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.NotTreasury.selector, admin, treasury)
+        );
+        pool.proposeTreasury(newSafe);
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.NotTreasury.selector, alice, treasury)
+        );
+        pool.proposeTreasury(newSafe);
+    }
+
+    function test_AcceptTreasury_RequiresPendingMatch() public {
+        vm.prank(treasury);
+        pool.proposeTreasury(newSafe);
+        assertEq(pool.pendingTreasury(), newSafe);
+
+        // Random address cannot accept
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.NotPendingTreasury.selector, alice, newSafe)
+        );
+        pool.acceptTreasury();
+
+        // Admin cannot accept
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.NotPendingTreasury.selector, admin, newSafe)
+        );
+        pool.acceptTreasury();
+
+        // pendingTreasury CAN accept
+        vm.prank(newSafe);
+        pool.acceptTreasury();
+
+        assertEq(pool.treasury(), newSafe, "rotated");
+        assertEq(pool.pendingTreasury(), address(0), "pending cleared");
+    }
+
+    function test_AcceptTreasury_RevertsIfNoPending() public {
+        vm.prank(newSafe);
+        vm.expectRevert(LiquidityPool.NoPendingTreasury.selector);
+        pool.acceptTreasury();
+    }
+
+    function test_CancelTreasuryProposal_ClearsPending() public {
+        vm.prank(treasury);
+        pool.proposeTreasury(newSafe);
+
+        vm.prank(treasury);
+        pool.cancelTreasuryProposal();
+        assertEq(pool.pendingTreasury(), address(0), "cleared");
+
+        // newSafe can no longer accept
+        vm.prank(newSafe);
+        vm.expectRevert(LiquidityPool.NoPendingTreasury.selector);
+        pool.acceptTreasury();
+    }
+
+    function test_AfterRotation_OldTreasuryLosesWithdrawalRights() public {
+        _accrueTreasury(200e6);
+
+        vm.prank(treasury);
+        pool.proposeTreasury(newSafe);
+        vm.prank(newSafe);
+        pool.acceptTreasury();
+
+        // Old treasury is now a regular address
+        vm.prank(treasury);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.NotTreasury.selector, treasury, newSafe)
+        );
+        pool.withdrawTreasury(100e6);
+
+        // New treasury can withdraw
+        vm.prank(newSafe);
+        pool.withdrawTreasury(100e6);
+        assertEq(usdc.balanceOf(newSafe), 100e6, "new treasury received funds");
+    }
+
+    function test_Admin_CannotRotateTreasury() public {
+        // The old admin-callable `setTreasury` is intentionally removed. The
+        // only path is propose/accept gated by the current treasury.
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.NotTreasury.selector, admin, treasury)
+        );
+        pool.proposeTreasury(newSafe);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // MAX BET AMOUNT (pool-wide cap)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_MaxBetAmount_EnforcedOnRecordBet() public {
+        _seedPool(100_000e6);
+        vm.prank(admin);
+        pool.setMaxBetAmount(100e6); // 100 USDC cap
+
+        uint256 marketId = _newMarketAtOdds(20_000);
+
+        // 100e6 is at the cap → allowed
+        _placeBet(alice, marketId, 0, 100e6);
+
+        // 101e6 → revert
+        vm.startPrank(alice);
+        usdc.approve(address(footballMatch), 101e6);
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidityPool.BetAmountAboveCap.selector, 101e6, 100e6)
+        );
+        footballMatch.placeBetUSDC(marketId, 0, 101e6);
+        vm.stopPrank();
+    }
+
+    function test_MaxBetAmount_ZeroDisablesCap() public {
+        _seedPool(100_000e6);
+        // default is 0 → disabled
+        uint256 marketId = _newMarketAtOdds(20_000);
+        _placeBet(alice, marketId, 0, 50_000e6); // huge bet, works
+        assertEq(pool.totalLiabilities(), 50_000e6, "big bet recorded");
+    }
+
+    function test_SetMaxBetAmount_OnlyAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(); // AccessControl revert
+        pool.setMaxBetAmount(100e6);
+
+        vm.prank(admin);
+        pool.setMaxBetAmount(500e6);
+        assertEq(pool.maxBetAmount(), 500e6);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // MAX ALLOWED ODDS (per-match soft cap)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_MaxAllowedOdds_BlocksSettingOddsAboveCap() public {
+        vm.prank(admin);
+        footballMatch.setMaxAllowedOdds(20_000); // 2.00x max
+
+        // Creating a market with 3.00x initial odds should revert
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BettingMatch.InvalidOddsValue.selector, uint32(30_000), uint32(10_001), uint32(20_000)
+            )
+        );
+        footballMatch.addMarketWithLine(MARKET_WINNER, 30_000, 0);
+    }
+
+    function test_MaxAllowedOdds_ZeroUsesDefaultMaxOdds() public {
+        // No setMaxAllowedOdds call → falls back to MAX_ODDS = 1_000_000 (100x)
+        vm.prank(admin);
+        footballMatch.addMarketWithLine(MARKET_WINNER, 500_000, 0); // 50x — allowed
+    }
+
+    function test_SetMaxAllowedOdds_RejectsOutOfRange() public {
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BettingMatch.InvalidOddsValue.selector,
+                uint32(5_000), uint32(10_001), uint32(1_000_000)
+            )
+        );
+        footballMatch.setMaxAllowedOdds(5_000); // below MIN_ODDS
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BettingMatch.InvalidOddsValue.selector,
+                uint32(2_000_000), uint32(10_001), uint32(1_000_000)
+            )
+        );
+        footballMatch.setMaxAllowedOdds(2_000_000); // above MAX_ODDS
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // UTILIZATION & MAX-WITHDRAW GATING
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_Utilization_ZeroWhenNoLiabilities() public {
+        _seedPool(10_000e6);
+        assertEq(pool.utilization(), 0, "zero utilization with no open bets");
+    }
+
+    function test_Utilization_ReflectsLiabilityShare() public {
+        _seedPool(10_000e6);
+        uint256 marketId = _newMarketAtOdds(20_000); // 2x → netExposure = netStake
+        _placeBet(alice, marketId, 0, 2_000e6);
+
+        // liab = 2000, totalAssets = 10_000 (stake in, liability out, no accrual).
+        // utilization = 2000 / 10_000 = 2000 bps = 20%.
+        assertEq(pool.utilization(), 2000, "20% utilization");
+    }
+
+    function test_MaxWithdraw_CappedByFreeBalance() public {
+        _seedPool(10_000e6);
+        uint256 marketId = _newMarketAtOdds(50_000); // 5x → netExposure = 4×stake
+        // Bet that locks big liability. netStake=2_000 at 5x → netExposure=8_000.
+        // After bet: pool USDC = 12_000, totalLiabilities = 8_000.
+        // LP NAV (totalAssets) = 12_000 − 8_000 = 4_000.
+        _placeBet(alice, marketId, 0, 2_000e6);
+
+        uint256 lpShareValue = pool.convertToAssets(pool.balanceOf(lp));
+        assertEq(lpShareValue, 4_000e6, "LP share-value tracks NAV");
+
+        uint256 cap = pool.maxWithdraw(lp);
+        assertEq(cap, 4_000e6, "maxWithdraw = min(shareValue, freeBalance) = 4_000");
+
+        // Attempting to withdraw above the cap reverts.
+        vm.prank(lp);
+        vm.expectRevert(); // OZ ERC4626: ERC4626ExceededMaxWithdraw
+        pool.withdraw(4_001e6, lp, lp);
+
+        // At-cap withdraw succeeds.
+        vm.prank(lp);
+        pool.withdraw(cap, lp, lp);
+    }
+
+    function test_FreeBalance_ExcludesAccruedTreasury() public {
+        _seedPool(10_000e6);
+        _accrueTreasury(500e6); // 1000 losing stake → 500 treasury + 500 LP
+
+        uint256 free = pool.freeBalance();
+        uint256 ta   = pool.totalAssets();
+        assertEq(free, ta, "freeBalance mirrors totalAssets");
+        // Pool USDC: 10_000 seed + 1_000 losing stake = 11_000.
+        // accruedTreasury = 500. LP NAV = 11_000 − 500 = 10_500.
+        assertEq(free, 10_500e6, "LP NAV = USDC minus accruedTreasury");
+        assertEq(pool.accruedTreasury(), 500e6, "treasury = 50% of losing");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _seedPool(uint256 amount) internal {
+        vm.startPrank(lp);
+        usdc.approve(address(pool), amount);
+        pool.deposit(amount, lp);
+        vm.stopPrank();
+    }
+
+    function _newMarketAtOdds(uint32 odds) internal returns (uint256 marketId) {
+        vm.prank(admin);
+        footballMatch.addMarketWithLine(MARKET_WINNER, odds, 0);
+        marketId = footballMatch.marketCount() - 1;
+        vm.prank(admin);
+        footballMatch.openMarket(marketId);
+    }
+
+    function _placeBet(address user, uint256 marketId, uint64 selection, uint256 amount) internal {
+        vm.startPrank(user);
+        usdc.approve(address(footballMatch), amount);
+        footballMatch.placeBetUSDC(marketId, selection, amount);
+        vm.stopPrank();
+    }
+
+    /// @dev Funds `accruedTreasury` to exactly `target` USDC by running one
+    ///      losing bet of `2 × target` net-stake (50% share → target).
+    ///      Assumes the pool is already seeded with enough LP capital; callers
+    ///      that don't seed themselves should call `_seedPool(100_000e6)` first.
+    function _accrueTreasury(uint256 target) internal {
+        if (pool.totalSupply() == 0) _seedPool(100_000e6);
+        uint256 losingStake = target * 2;
+        uint256 marketId = _newMarketAtOdds(20_000);
+        _placeBet(alice, marketId, 0, losingStake);
+        vm.prank(admin);
+        footballMatch.closeMarket(marketId);
+        vm.prank(resolver);
+        footballMatch.resolveMarket(marketId, 1); // alice's selection 0 loses
+    }
+}


### PR DESCRIPTION
Implements the 50/50 losing-stake split agreed in the treasury design session and ships the operational hardening that goes with it.

Core mechanics:
- settleMarket now accrues 50% of losing net stake to a pull-based treasury claim (TREASURY_SHARE_BPS = 5000). The other 50% stays in the pool and compounds into LP NAV.
- totalAssets() subtracts accruedTreasury so LP share price reflects only LP capital — no double-counting of the treasury's share.
- withdrawTreasury(amount) is gated by min(accruedTreasury, USDC balance
  - totalLiabilities) so outstanding bet payouts always have precedence.

Role separation (enforced on-chain):
- 2-step treasury rotation: proposeTreasury → acceptTreasury, callable ONLY by the current treasury. Admin cannot rotate or touch accrued funds. setTreasury (admin-callable) removed.
- Admin key (DEFAULT_ADMIN_ROLE) runs operational setters + upgrades. Treasury Safe (state var) controls rotation + withdrawal.

Hardening:
- ERC-4626 _decimalsOffset = 6 closes the first-depositor inflation attack (ctvLP now 12 decimals).
- maxBetAmount: pool-wide per-bet cap (admin-settable, 0 = disabled).
- maxAllowedOdds: per-BettingMatch soft cap (admin-settable, 0 uses hardcoded MAX_ODDS = 100x).
- utilization() view + maxWithdraw/maxRedeem capped by freeBalance.

Deploy + upgrade:
- New script/DeployLiquidityPool.s.sol enforces ADMIN_ADDRESS ≠ SAFE_ADDRESS at deploy time.
- New script/UpgradeLiquidityPool.s.sol with storage-layout safety checklist in NatSpec.
- DeployAll.s.sol: stale PayoutEscrow references replaced with pointers to the new pool deploy script.

Tests: 153/153 passing (122 existing + 26 V2 unit tests + 5 Foundry invariant tests each fuzzed across 128k calls). Invariants: solvency, NAV identity, treasury accrual monotonicity, admin ≠ treasury, withdrawable bounded.

Docs: treasury.md, payout.md, README.md, DEPLOYMENT_SUMMARY.md, script/README.md all refreshed for the new role model. New docs/liquidity-providers.md covers LP-facing mechanics, worked examples, and the treasury-asymmetry disclosure.

Storage layout is append-only: both LiquidityPool (__gap 43→40) and BettingMatch (__gap 38→35) shrink their gap by the number of new named slots. Existing proxies can be upgraded in place.