### PR TITLE
🔒 Audit fixes: swap-router validation, atomic match wiring, role hard…

### DIFF
--- a/chiliz-tv/script/DeployAll.s.sol
+++ b/chiliz-tv/script/DeployAll.s.sol
@@ -140,6 +140,11 @@ contract DeployAll is Script {
         console.log("StreamWalletFactory.setSwapRouter ->", address(swapRouter));
         swapRouter.setStreamWalletFactory(address(streamFactory));
         console.log("ChilizSwapRouter.setStreamWalletFactory ->", address(streamFactory));
+        // CRITICAL: register the BettingMatchFactory on the swap router. Without
+        // this call every `placeBetWith*` reverts with `BettingMatchFactoryNotSet`
+        // — the router never silently forwards USDC to an unvalidated match.
+        swapRouter.setMatchFactory(address(bettingFactory));
+        console.log("ChilizSwapRouter.setMatchFactory    ->", address(bettingFactory));
         console.log("");
     }
 
@@ -191,14 +196,22 @@ contract DeployAll is Script {
         console.log("   ADMIN_ADDRESS and SAFE_ADDRESS envs):");
         console.log("   forge script script/DeployLiquidityPool.s.sol --rpc-url $RPC_URL --broadcast");
         console.log("");
-        console.log("1. For each BettingMatch proxy created by the factory:");
-        console.log("   a) cast send <MATCH> 'setUSDCToken(address)'", usdcAddress);
-        console.log("   b) cast send <MATCH> 'setLiquidityPool(address)' <LIQUIDITY_POOL>");
-        console.log("   c) cast send <LIQUIDITY_POOL> 'authorizeMatch(address)' <MATCH>   # from ADMIN_ADDRESS");
-        console.log("   d) cast send <MATCH> 'grantRole(bytes32,address)' $(cast keccak 'SWAP_ROUTER_ROLE')", address(swapRouter));
-        console.log("   e) cast send <MATCH> 'grantRole(bytes32,address)' $(cast keccak 'RESOLVER_ROLE') <ORACLE>");
-        console.log("   f) cast send <MATCH> 'setMaxAllowedOdds(uint32)' <cap>   # recommended");
-        console.log("2. Seed LiquidityPool with USDC:");
+        console.log("1. Wire the BettingMatchFactory (H-4 atomic wiring):");
+        console.log("   a) cast send <BETTING_FACTORY> 'setWiring(address,address,address)' \\");
+        console.log("        <LIQUIDITY_POOL>", usdcAddress, address(swapRouter));
+        console.log("      Factory owner only (deployer until ownership transfer).");
+        console.log("   b) cast send <LIQUIDITY_POOL> 'grantRole(bytes32,address)' \\");
+        console.log("        $(cast keccak 'MATCH_AUTHORIZER_ROLE') <BETTING_FACTORY>");
+        console.log("      From ADMIN_ADDRESS (pool DEFAULT_ADMIN_ROLE).");
+        console.log("   Once wired, `factory.createFootballMatch(name, owner, oracle)` does");
+        console.log("   all match-side setup + pool authorization in a single transaction.");
+        console.log("");
+        console.log("2. Create matches (after step 1):");
+        console.log("   cast send <BETTING_FACTORY> \\");
+        console.log("     'createFootballMatch(string,address,address)' <NAME> <MATCH_OWNER> <ORACLE>");
+        console.log("   cast send <MATCH> 'setMaxAllowedOdds(uint32)' <cap>   # optional, post-create");
+        console.log("");
+        console.log("3. Seed LiquidityPool with USDC:");
         console.log("   Step A: cast send <USDC> 'approve(address,uint256)' <LIQUIDITY_POOL> <AMOUNT>");
         console.log("   Step B: cast send <LIQUIDITY_POOL> 'deposit(uint256,address)' <AMOUNT> <RECEIVER>");
         console.log("=========================================");

--- a/chiliz-tv/script/DeployBetting.s.sol
+++ b/chiliz-tv/script/DeployBetting.s.sol
@@ -1,172 +1,126 @@
-// forge script script/DeployAll.s.sol:DeployAll \
-//   --rpc-url https://spicy-rpc.chiliz.com \
-//   --private-key $PRIVATE_KEY \
-//   --broadcast \
-//   --verify \
-//   --verifier blockscout \
-//   --verifier-url https://api.routescan.io/v2/network/testnet/evm/88882/etherscan/api \
-//   --etherscan-api-key $ETHERSCAN_API_KEY \
-//   --with-gas-price 100000000000 \
-//   -vvvv// SPDX-License-Identifier: MIT
-
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
 import {Script, console} from "forge-std/Script.sol";
 
-// Import betting system factory (implementations deployed internally)
 import {BettingMatchFactory} from "../src/betting/BettingMatchFactory.sol";
 
 /**
  * @title DeployBetting
  * @author ChilizTV
- * @notice Deployment script for the UUPS-based Multi-Sport Betting System
- * @dev Deploys FootballMatch and BasketballMatch implementations, plus BettingMatchFactory
- * 
- * ARCHITECTURE:
- * ============
- * - FootballMatch: UUPS upgradeable contract for football betting
- * - BasketballMatch: UUPS upgradeable contract for basketball betting
- * - BettingMatchFactory: Factory to deploy ERC1967 proxies for both sports
- * - Each proxy is an independent match with sport-specific markets
- * 
- * BETTING FLOW:
- * ============
- * 1. Factory creates a new football or basketball match proxy
- * 2. Match owner adds sport-specific markets
- * 3. Users bet CHZ on market selections
- * 4. Match owner resolves markets with actual results
- * 5. Winners claim payouts based on odds
- * 
+ * @notice Deployment script for the UUPS-based Multi-Sport Betting System.
+ *         Deploys the `BettingMatchFactory` (which itself deploys the initial
+ *         FootballMatch + BasketballMatch implementations in its constructor).
+ *
+ * POST-DEPLOY (required before any match is created):
+ * ===================================================
+ *  1. From factory OWNER:
+ *       factory.setWiring(<LIQUIDITY_POOL>, <USDC>, <CHILIZ_SWAP_ROUTER>)
+ *     Until this is called, `createFootballMatch` / `createBasketballMatch`
+ *     revert with `WiringNotConfigured`.
+ *
+ *  2. From pool DEFAULT_ADMIN_ROLE holder:
+ *       pool.grantRole(MATCH_AUTHORIZER_ROLE, <FACTORY>)
+ *     The factory calls `pool.authorizeMatch(proxy)` atomically when it
+ *     creates a match — without this role the whole match-creation tx
+ *     reverts.
+ *
+ *  3. From ChilizSwapRouter owner (if not already set):
+ *       swapRouter.setMatchFactory(<FACTORY>)
+ *     Without this, every `placeBetWith*` reverts with
+ *     `BettingMatchFactoryNotSet` (C-1 hardening — no silent forwards).
+ *
  * USAGE:
- * =====
- * Set environment variables:
- *   export PRIVATE_KEY=0x...           # Deployer private key
- *   export RPC_URL=https://...         # Network RPC endpoint
- * 
- * Run:
+ * ======
+ *   export PRIVATE_KEY=0x...
+ *   export RPC_URL=https://spicy-rpc.chiliz.com
  *   forge script script/DeployBetting.s.sol --rpc-url $RPC_URL --broadcast --verify
  */
 contract DeployBetting is Script {
-    
-    // ============================================================================
-    // DEPLOYED CONTRACTS
-    // ============================================================================
-    
+
     BettingMatchFactory public factory;
-    
     address public deployer;
-    
-    
-    // ============================================================================
-    // MAIN DEPLOYMENT
-    // ============================================================================
-    
+
     function run() external {
         deployer = msg.sender;
-        
+
         vm.startBroadcast();
-        
         _printHeader();
         _deployFactory();
         _printSummary();
-        
         vm.stopBroadcast();
     }
-    
-    
-    // ============================================================================
-    // DEPLOYMENT STEPS
-    // ============================================================================
-    
+
     /**
-     * @notice Deploy BettingMatchFactory (deploys implementations internally)
-     * @dev Factory creates ERC1967 proxies for both sports
+     * @notice Deploy `BettingMatchFactory`. Football + basketball implementations
+     *         are deployed internally by the factory's constructor.
      */
     function _deployFactory() internal {
         console.log("Deploying BettingMatchFactory");
         console.log("------------------------------");
         factory = new BettingMatchFactory();
-        console.log("BettingMatchFactory:", address(factory));
-        console.log("  Owner:", deployer);
-        console.log("  Implementations deployed internally");
+        console.log("BettingMatchFactory:      ", address(factory));
+        console.log("  Owner:                  ", deployer);
+        console.log("  Football impl:          ", factory.footballImplementation());
+        console.log("  Basketball impl:        ", factory.basketballImplementation());
         console.log("");
     }
-    
-    
-    // ============================================================================
-    // HELPER FUNCTIONS
-    // ============================================================================
-    
+
     function _printHeader() internal view {
         console.log("=========================================");
         console.log("CHILIZ-TV MULTI-SPORT BETTING DEPLOYMENT");
         console.log("=========================================");
-        console.log("");
         console.log("Deployer:", deployer);
         console.log("");
-        console.log("=========================================");
-        console.log("");
     }
-    
+
     function _printSummary() internal view {
-        console.log("=====================================");
-        console.log("DEPLOYMENT COMPLETE!");
-        console.log("=====================================");
-        console.log("");
-        
-        console.log("DEPLOYED CONTRACTS:");
-        console.log("------------------");
+        console.log("=========================================");
+        console.log("DEPLOYMENT COMPLETE");
+        console.log("=========================================");
         console.log("BettingMatchFactory:", address(factory));
-        console.log("  (Implementations deployed internally)");
         console.log("");
-        
-        console.log("CREATE A FOOTBALL MATCH:");
-        console.log("-----------------------");
+
+        console.log("POST-DEPLOYMENT WIRING (MANDATORY):");
+        console.log("-----------------------------------");
+        console.log("1) Configure the factory (factory owner):");
+        console.log("   cast send", address(factory));
+        console.log("     'setWiring(address,address,address)'");
+        console.log("     <LIQUIDITY_POOL> <USDC> <CHILIZ_SWAP_ROUTER>");
+        console.log("");
+        console.log("2) Grant MATCH_AUTHORIZER_ROLE on the pool (pool admin):");
+        console.log("   cast send <LIQUIDITY_POOL>");
+        console.log("     'grantRole(bytes32,address)'");
+        console.log("     $(cast keccak 'MATCH_AUTHORIZER_ROLE')", address(factory));
+        console.log("");
+        console.log("3) Register the factory on the swap router (router owner):");
+        console.log("   cast send <CHILIZ_SWAP_ROUTER>");
+        console.log("     'setMatchFactory(address)'", address(factory));
+        console.log("");
+
+        console.log("CREATE A FOOTBALL MATCH (atomic - wires pool + roles):");
+        console.log("------------------------------------------------------");
         console.log("cast send", address(factory));
-        console.log("  'createFootballMatch(string,address)'");
-        console.log("  'Barcelona vs Real Madrid'  # Match name");
-        console.log("  <OWNER_ADDRESS>             # Match admin");
+        console.log("  'createFootballMatch(string,address,address)'");
+        console.log("  'Barcelona vs Real Madrid'  # match name");
+        console.log("  <MATCH_OWNER>               # DEFAULT_ADMIN / ADMIN / PAUSER / ODDS_SETTER");
+        console.log("  <ORACLE>                    # RESOLVER_ROLE holder");
         console.log("");
-        
+
         console.log("CREATE A BASKETBALL MATCH:");
-        console.log("-------------------------");
+        console.log("--------------------------");
         console.log("cast send", address(factory));
-        console.log("  'createBasketballMatch(string,address)'");
-        console.log("  'Lakers vs Celtics'    # Match name");
-        console.log("  <OWNER_ADDRESS>        # Match admin");
+        console.log("  'createBasketballMatch(string,address,address)'");
+        console.log("  'Lakers vs Celtics'");
+        console.log("  <MATCH_OWNER>");
+        console.log("  <ORACLE>");
         console.log("");
-        
-        console.log("ADD MARKETS TO MATCH:");
-        console.log("--------------------");
-        console.log("cast send <MATCH_ADDRESS>");
-        console.log("  'addMarketWithLine(bytes32,uint32,int16)'");
-        console.log("  keccak256('WINNER')       # Market type (bytes32)");
-        console.log("  20000                     # Odds: 2.0x (20000/10000)");
-        console.log("  0                         # Line: 0 (no line)");
-        console.log("");
-        
-        console.log("BETTING FLOW:");
-        console.log("------------");
-        console.log("1. Open market: match.setMarketState(0, MarketState.Open)");
-        console.log("2. User bets USDC: match.placeBetUSDC(0, 0, 100e6)");
-        console.log("   - marketId: 0 (first market)");
-        console.log("   - selection: 0 (Home/Over/Yes/etc.)");
-        console.log("   - amount: 100 USDC (6 decimals)");
-        console.log("   - Or swap any token via ChilizSwapRouter");
-        console.log("   - Odds locked at time of bet (x10000 precision)");
-        console.log("3. Owner resolves: match.resolveMarket(0, 0)");
-        console.log("   - marketId: 0");
-        console.log("   - result: 0 (actual outcome)");
-        console.log("4. Winner claims: match.claim(0, 0)");
-        console.log("   - Receives USDC: bet * lockedOdds / 10000");
-        console.log("");
-        
+
         console.log("UPGRADING:");
-        console.log("---------");
-        console.log("Implementations are immutable in factory.");
-        console.log("Each match can be upgraded individually via UUPS:");
-        console.log("  1. Deploy new implementation (FootballMatch or BasketballMatch)");
-        console.log("  2. Call match.upgradeToAndCall(newImpl, '') as match owner");
+        console.log("----------");
+        console.log("Each match proxy is UUPS. Upgrade individually from DEFAULT_ADMIN:");
+        console.log("  1. Deploy the new FootballMatch / BasketballMatch implementation.");
+        console.log("  2. proxy.upgradeToAndCall(newImpl, '') from the match admin.");
         console.log("");
     }
 }

--- a/chiliz-tv/script/SetupFootballMatch.s.sol
+++ b/chiliz-tv/script/SetupFootballMatch.s.sol
@@ -103,13 +103,21 @@ contract SetupFootballMatch is Script {
     function _createMatch() internal {
         console.log("STEP 1: Creating Football Match");
         console.log("================================");
-        
-        matchAddress = factory.createFootballMatch(MATCH_NAME, deployer);
+
+        // Oracle (RESOLVER_ROLE holder). Defaults to deployer when ORACLE_ADDRESS is unset,
+        // so this script remains runnable on local/test networks. In production, set
+        // ORACLE_ADDRESS to a dedicated oracle key — separating resolver from match admin.
+        address oracle;
+        try vm.envAddress("ORACLE_ADDRESS") returns (address o) { oracle = o; }
+        catch { oracle = deployer; }
+
+        matchAddress = factory.createFootballMatch(MATCH_NAME, deployer, oracle);
         match_ = FootballMatch(payable(matchAddress));
 
         console.log("Match Name:", MATCH_NAME);
         console.log("Match Address:", matchAddress);
         console.log("Owner:", deployer);
+        console.log("Oracle (RESOLVER_ROLE):", oracle);
         console.log("");
     }
     

--- a/chiliz-tv/src/betting/BettingMatchFactory.sol
+++ b/chiliz-tv/src/betting/BettingMatchFactory.sol
@@ -5,6 +5,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {FootballMatch} from "./FootballMatch.sol";
 import {BasketballMatch} from "./BasketballMatch.sol";
+import {BettingMatch} from "./BettingMatch.sol";
+import {ILiquidityPool} from "../interfaces/ILiquidityPool.sol";
 
 /// @title BettingMatchFactory
 /// @notice Factory contract to deploy UUPS-upgradeable sport-specific match proxies.
@@ -13,9 +15,17 @@ import {BasketballMatch} from "./BasketballMatch.sol";
 ///      are NOT auto-upgraded; their DEFAULT_ADMIN_ROLE holder must call
 ///      upgradeToAndCall directly (or use the UpgradeBetting script).
 ///
-///      A single shared PayoutEscrow is deployed separately and manages a whitelist
-///      of authorized match proxies. After creating a match, authorize it on the
-///      escrow via PayoutEscrow.authorizeMatch(matchProxy, cap).
+///      Atomic wiring: `createFootballMatch` / `createBasketballMatch` initialize the
+///      match with the factory as temporary admin, then in the same transaction:
+///        (1) set USDC + LiquidityPool addresses on the match,
+///        (2) grant SWAP_ROUTER_ROLE and RESOLVER_ROLE,
+///        (3) grant all admin roles to the intended owner + transfer Ownable,
+///        (4) renounce every role held by the factory (DEFAULT_ADMIN last),
+///        (5) call `pool.authorizeMatch(proxy)` to whitelist the match.
+///
+///      Step (5) requires the factory to hold `MATCH_AUTHORIZER_ROLE` on the pool —
+///      granted once at deploy time by the pool admin. After construction the
+///      match is fully live and ready for bets; no manual cast-send sequence.
 contract BettingMatchFactory is Ownable {
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -24,6 +34,12 @@ contract BettingMatchFactory is Ownable {
 
     /// @notice Sport types supported by the factory
     enum SportType { FOOTBALL, BASKETBALL }
+
+    /// @notice Back-compat shorthand for `SportType.FOOTBALL` / `SportType.BASKETBALL`,
+    ///         accessible as `BettingMatchFactory.FOOTBALL` / `.BASKETBALL` from
+    ///         legacy scripts that predate the named-getter API.
+    uint8 public constant FOOTBALL   = uint8(SportType.FOOTBALL);
+    uint8 public constant BASKETBALL = uint8(SportType.BASKETBALL);
 
     // ══════════════════════════════════════════════════════════════════════════
     // STATE
@@ -46,11 +62,21 @@ contract BettingMatchFactory is Ownable {
     /// @dev Mutable — update via setBasketballImplementation(). Existing proxies unaffected.
     address public basketballImplementation;
 
+    /// @notice LiquidityPool that new matches are wired to.
+    /// @dev Must be set via `setWiring` before any match is created.
+    address public liquidityPool;
+
+    /// @notice USDC token set on every new match.
+    address public usdcToken;
+
+    /// @notice ChilizSwapRouter granted SWAP_ROUTER_ROLE on every new match.
+    address public swapRouter;
+
     // ══════════════════════════════════════════════════════════════════════════
     // EVENTS
     // ══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Emitted when a new match proxy is created
+    /// @notice Emitted when a new match proxy is created (post-wiring)
     event MatchCreated(address indexed proxy, SportType sportType, address indexed owner);
 
     /// @notice Emitted when the football implementation pointer is updated
@@ -59,12 +85,16 @@ contract BettingMatchFactory is Ownable {
     /// @notice Emitted when the basketball implementation pointer is updated
     event BasketballImplementationUpdated(address indexed oldImpl, address indexed newImpl);
 
+    /// @notice Emitted when the post-deploy wiring config is updated
+    event WiringSet(address indexed liquidityPool, address indexed usdcToken, address indexed swapRouter);
+
     // ══════════════════════════════════════════════════════════════════════════
     // ERRORS
     // ══════════════════════════════════════════════════════════════════════════
 
     error MatchNotFound(address matchAddress);
     error InvalidAddress();
+    error WiringNotConfigured();
 
     // ══════════════════════════════════════════════════════════════════════════
     // CONSTRUCTOR
@@ -77,46 +107,84 @@ contract BettingMatchFactory is Ownable {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    // WIRING CONFIG
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Set the pool / USDC / swap router addresses that new matches are wired to.
+    /// @dev Must be called before the first `createFootballMatch` / `createBasketballMatch`.
+    ///      Pool admin must additionally grant `MATCH_AUTHORIZER_ROLE` on the pool to
+    ///      this factory, otherwise the in-transaction `pool.authorizeMatch` call reverts.
+    function setWiring(address _liquidityPool, address _usdcToken, address _swapRouter)
+        external
+        onlyOwner
+    {
+        if (_liquidityPool == address(0) || _usdcToken == address(0) || _swapRouter == address(0)) {
+            revert InvalidAddress();
+        }
+        liquidityPool = _liquidityPool;
+        usdcToken     = _usdcToken;
+        swapRouter    = _swapRouter;
+        emit WiringSet(_liquidityPool, _usdcToken, _swapRouter);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     // MATCH DEPLOYMENT
     // ══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Deploy a new FootballMatch UUPS proxy and initialize it
+    /// @notice Deploy, initialize, and fully wire a FootballMatch UUPS proxy.
     /// @param _matchName Human-readable match name
-    /// @param _owner     Address that receives DEFAULT_ADMIN_ROLE on the proxy
-    /// @return proxy     Address of the newly deployed proxy
+    /// @param _owner     Address that receives ownership + admin roles on the match
+    /// @param _oracle    Address that receives `RESOLVER_ROLE` on the match
+    /// @return proxy     Address of the newly deployed, ready-to-bet match
     function createFootballMatch(
         string calldata _matchName,
-        address _owner
+        address _owner,
+        address _oracle
     ) external onlyOwner returns (address proxy) {
+        _requireWiring();
+        if (_owner == address(0) || _oracle == address(0)) revert InvalidAddress();
+
+        // Initialize with the factory as temp admin so we can configure + hand off.
         bytes memory initData = abi.encodeWithSelector(
             FootballMatch.initialize.selector,
             _matchName,
-            _owner
+            address(this)
         );
         proxy = address(new ERC1967Proxy(footballImplementation, initData));
         allMatches.push(proxy);
         isMatch[proxy]        = true;
         matchSportType[proxy] = SportType.FOOTBALL;
+
+        _wireMatch(proxy, _owner, _oracle);
+
         emit MatchCreated(proxy, SportType.FOOTBALL, _owner);
     }
 
-    /// @notice Deploy a new BasketballMatch UUPS proxy and initialize it
+    /// @notice Deploy, initialize, and fully wire a BasketballMatch UUPS proxy.
     /// @param _matchName Human-readable match name
-    /// @param _owner     Address that receives DEFAULT_ADMIN_ROLE on the proxy
-    /// @return proxy     Address of the newly deployed proxy
+    /// @param _owner     Address that receives ownership + admin roles on the match
+    /// @param _oracle    Address that receives `RESOLVER_ROLE` on the match
+    /// @return proxy     Address of the newly deployed, ready-to-bet match
     function createBasketballMatch(
         string calldata _matchName,
-        address _owner
+        address _owner,
+        address _oracle
     ) external onlyOwner returns (address proxy) {
+        _requireWiring();
+        if (_owner == address(0) || _oracle == address(0)) revert InvalidAddress();
+
         bytes memory initData = abi.encodeWithSelector(
             BasketballMatch.initialize.selector,
             _matchName,
-            _owner
+            address(this)
         );
         proxy = address(new ERC1967Proxy(basketballImplementation, initData));
         allMatches.push(proxy);
         isMatch[proxy]        = true;
         matchSportType[proxy] = SportType.BASKETBALL;
+
+        _wireMatch(proxy, _owner, _oracle);
+
         emit MatchCreated(proxy, SportType.BASKETBALL, _owner);
     }
 
@@ -155,5 +223,64 @@ contract BettingMatchFactory is Ownable {
     function getSportType(address matchAddress) external view returns (SportType) {
         if (!isMatch[matchAddress]) revert MatchNotFound(matchAddress);
         return matchSportType[matchAddress];
+    }
+
+    /// @notice Back-compat accessor: look up an implementation address by sport id.
+    /// @dev    Legacy callers used `factory.implementations(FOOTBALL)`. The modern
+    ///         equivalents are `footballImplementation()` / `basketballImplementation()`.
+    ///         Kept here so older deployment scripts compile unchanged.
+    function implementations(uint8 sport) external view returns (address) {
+        if (sport == FOOTBALL)   return footballImplementation;
+        if (sport == BASKETBALL) return basketballImplementation;
+        revert InvalidAddress();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // INTERNAL
+    // ══════════════════════════════════════════════════════════════════════════
+
+    function _requireWiring() internal view {
+        if (liquidityPool == address(0) || usdcToken == address(0) || swapRouter == address(0)) {
+            revert WiringNotConfigured();
+        }
+    }
+
+    /// @dev Full wiring sequence for a freshly-initialized match where the factory
+    ///      is the current DEFAULT_ADMIN / ADMIN / PAUSER / ODDS_SETTER and Ownable owner.
+    ///      After this function:
+    ///        - match is configured with USDC + LiquidityPool
+    ///        - swap router + oracle have their roles
+    ///        - intended owner holds every admin role + Ownable ownership
+    ///        - factory holds NO role on the match
+    ///        - match is authorized on the pool (MATCH_ROLE granted)
+    function _wireMatch(address proxy, address _owner, address _oracle) internal {
+        BettingMatch m = BettingMatch(payable(proxy));
+
+        // 1) Wire USDC + pool (ADMIN_ROLE-gated).
+        m.setUSDCToken(usdcToken);
+        m.setLiquidityPool(liquidityPool);
+
+        // 2) Grant operational roles (DEFAULT_ADMIN_ROLE-gated).
+        m.grantRole(m.SWAP_ROUTER_ROLE(), swapRouter);
+        m.grantRole(m.RESOLVER_ROLE(),    _oracle);
+
+        // 3) Hand admin roles to the intended owner.
+        m.grantRole(m.DEFAULT_ADMIN_ROLE(), _owner);
+        m.grantRole(m.ADMIN_ROLE(),        _owner);
+        m.grantRole(m.PAUSER_ROLE(),       _owner);
+        m.grantRole(m.ODDS_SETTER_ROLE(),  _owner);
+        m.transferOwnership(_owner);
+
+        // 4) Authorize the match on the pool BEFORE we drop our admin — if the
+        //    factory doesn't hold MATCH_AUTHORIZER_ROLE on the pool this reverts
+        //    and the entire match deployment is rolled back.
+        ILiquidityPool(liquidityPool).authorizeMatch(proxy);
+
+        // 5) Renounce every role the factory still holds. DEFAULT_ADMIN_ROLE last
+        //    because it is the admin role for the others in AccessControl.
+        m.renounceRole(m.ADMIN_ROLE(),         address(this));
+        m.renounceRole(m.PAUSER_ROLE(),        address(this));
+        m.renounceRole(m.ODDS_SETTER_ROLE(),   address(this));
+        m.renounceRole(m.DEFAULT_ADMIN_ROLE(), address(this));
     }
 }

--- a/chiliz-tv/src/interfaces/ILiquidityPool.sol
+++ b/chiliz-tv/src/interfaces/ILiquidityPool.sol
@@ -95,6 +95,17 @@ interface ILiquidityPool {
     /// @notice Set a pool-wide maximum per-bet netStake. 0 = disabled.
     function setMaxBetAmount(uint256 newMax) external;
 
+    /// @notice Grant `MATCH_ROLE` to a match proxy, allowing it to call
+    ///         `recordBet` / `settleMarket` / `payWinner` / `payRefund`.
+    /// @dev    Callable by holders of `DEFAULT_ADMIN_ROLE` or the narrower
+    ///         `MATCH_AUTHORIZER_ROLE` (granted to the `BettingMatchFactory`
+    ///         so it can register matches atomically with their creation).
+    function authorizeMatch(address bettingMatch) external;
+
+    /// @notice Revoke `MATCH_ROLE` from a match proxy.
+    /// @dev    Same access as `authorizeMatch`.
+    function revokeMatch(address bettingMatch) external;
+
     // -----------------------------------------------------------------------
     // Views
     // -----------------------------------------------------------------------

--- a/chiliz-tv/src/liquidity/LiquidityPool.sol
+++ b/chiliz-tv/src/liquidity/LiquidityPool.sol
@@ -64,9 +64,14 @@ contract LiquidityPool is
     // ROLES
     // ═══════════════════════════════════════════════════════════════════════
 
-    bytes32 public constant MATCH_ROLE  = keccak256("MATCH_ROLE");
-    bytes32 public constant ROUTER_ROLE = keccak256("ROUTER_ROLE");
-    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant MATCH_ROLE            = keccak256("MATCH_ROLE");
+    bytes32 public constant ROUTER_ROLE           = keccak256("ROUTER_ROLE");
+    bytes32 public constant PAUSER_ROLE           = keccak256("PAUSER_ROLE");
+    /// @notice Narrow role allowed to grant/revoke `MATCH_ROLE` on match proxies.
+    ///         Intended to be granted to the `BettingMatchFactory` so it can
+    ///         authorize a freshly-deployed match atomically with its creation.
+    ///         DEFAULT_ADMIN_ROLE retains the same authority as a superset.
+    bytes32 public constant MATCH_AUTHORIZER_ROLE = keccak256("MATCH_AUTHORIZER_ROLE");
 
     // ═══════════════════════════════════════════════════════════════════════
     // CONSTANTS
@@ -189,6 +194,7 @@ contract LiquidityPool is
     error ZeroAmount();
     error BpsOutOfRange(uint16 provided, uint16 max);
     error MatchNotAuthorized(address bettingMatch);
+    error NotMatchAuthorizer(address caller);
     error CooldownActive(address holder, uint48 unlocksAt);
     error InsufficientFreeBalance(uint256 requested, uint256 free);
     error MarketLiabilityCapExceeded(uint256 requested, uint256 cap);
@@ -551,10 +557,22 @@ contract LiquidityPool is
     // GOVERNANCE (DEFAULT_ADMIN_ROLE)
     // ═══════════════════════════════════════════════════════════════════════
 
+    /// @dev Accepts either DEFAULT_ADMIN_ROLE (full admin) or the narrower
+    ///      MATCH_AUTHORIZER_ROLE (granted to the BettingMatchFactory). Lets a
+    ///      factory atomically register the match it just deployed without
+    ///      holding full pool admin.
+    modifier onlyMatchAuthorizer() {
+        if (
+            !hasRole(DEFAULT_ADMIN_ROLE, msg.sender) &&
+            !hasRole(MATCH_AUTHORIZER_ROLE, msg.sender)
+        ) revert NotMatchAuthorizer(msg.sender);
+        _;
+    }
+
     /// @notice Grants MATCH_ROLE to a match proxy.
     function authorizeMatch(address bettingMatch)
         external
-        onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyMatchAuthorizer
     {
         if (bettingMatch == address(0)) revert ZeroAddress();
         _grantRole(MATCH_ROLE, bettingMatch);
@@ -564,7 +582,7 @@ contract LiquidityPool is
     /// @notice Revokes MATCH_ROLE from a match proxy.
     function revokeMatch(address bettingMatch)
         external
-        onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyMatchAuthorizer
     {
         _revokeRole(MATCH_ROLE, bettingMatch);
         emit MatchRevoked(bettingMatch);

--- a/chiliz-tv/src/streamer/StreamWallet.sol
+++ b/chiliz-tv/src/streamer/StreamWallet.sol
@@ -156,11 +156,16 @@ contract StreamWallet is Initializable, OwnableUpgradeable, UUPSUpgradeable, Ree
     //////////////////////////////////////////////////////////////*/
 
     /**
-     * @notice Set the authorized swap router address
+     * @notice Set the authorized swap router address.
+     * @dev    Factory-only. Previously the streamer (owner) could also rotate
+     *         this, which let a rogue streamer redirect `recordDonationByRouter`
+     *         / `recordSubscriptionByRouter` to a contract they control and
+     *         fabricate revenue events. Router rotation is a protocol-wide
+     *         concern and must stay with the factory.
      * @param _swapRouter The ChilizSwapRouter address
      */
     function setSwapRouter(address _swapRouter) external {
-        if (msg.sender != factory && msg.sender != owner()) revert OnlyAuthorized();
+        if (msg.sender != factory) revert OnlyAuthorized();
         if (_swapRouter == address(0)) revert InvalidAddress();
         address old = swapRouter;
         swapRouter = _swapRouter;

--- a/chiliz-tv/src/swap/ChilizSwapRouter.sol
+++ b/chiliz-tv/src/swap/ChilizSwapRouter.sol
@@ -72,9 +72,10 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
     /// @notice StreamWalletFactory for wallet lookup/creation
     StreamWalletFactory public streamWalletFactory;
 
-    /// @notice BettingMatchFactory for validating that bettingMatch addresses are legitimate
-    /// @dev Optional: if unset, no validation is performed (backward-compatible).
-    ///      Should be set immediately after deployment.
+    /// @notice BettingMatchFactory for validating that bettingMatch addresses are legitimate.
+    /// @dev MUST be set before any `placeBetWith*` call — validation is always enforced.
+    ///      If unset, all betting entrypoints revert with `BettingMatchFactoryNotSet`.
+    ///      Deploy flow: deploy this router, deploy factory, call `setMatchFactory(factory)`.
     BettingMatchFactory public bettingMatchFactory;
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -181,10 +182,23 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
     error TokenIsUSDC();
     /// @notice Thrown when bettingMatch was not deployed by the registered factory
     error UnauthorizedBettingMatch(address bettingMatch);
+    /// @notice Thrown when a bet is attempted before the BettingMatchFactory has been
+    ///         registered via `setMatchFactory`. Prevents silent USDC theft through
+    ///         unvalidated `bettingMatch` addresses.
+    error BettingMatchFactoryNotSet();
     /// @notice Thrown when setStreamWalletFactory is called but the factory's swapRouter
     ///         is not this contract — prevents a misconfiguration that would silently
     ///         revert every streaming recording call.
     error RouterNotConfiguredOnFactory();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // EVENTS — ADMIN
+    // ══════════════════════════════════════════════════════════════════════════
+
+    event TreasurySet(address indexed oldTreasury, address indexed newTreasury);
+    event PlatformFeeBpsSet(uint16 oldFeeBps, uint16 newFeeBps);
+    event MatchFactorySet(address indexed oldFactory, address indexed newFactory);
+    event StreamWalletFactorySet(address indexed oldFactory, address indexed newFactory);
 
     // ══════════════════════════════════════════════════════════════════════════
     // CONSTRUCTOR
@@ -303,11 +317,13 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
         if (token == address(usdc)) revert TokenIsUSDC();
         if (block.timestamp > deadline) revert DeadlinePassed();
 
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-        uint256 usdcReceived = _swapTokensToUSDC(token, amount, amountOutMin, deadline);
+        // Measure the actual amount received to stay safe with fee-on-transfer
+        // / rebasing tokens — we swap what we *hold*, not what the user declared.
+        uint256 received = _pullToken(IERC20(token), msg.sender, amount);
+        uint256 usdcReceived = _swapTokensToUSDC(token, received, amountOutMin, deadline);
         _placeBetOnBehalf(bettingMatch, marketId, selection, usdcReceived);
 
-        emit BetPlacedViaToken(bettingMatch, msg.sender, token, amount, usdcReceived, marketId, selection);
+        emit BetPlacedViaToken(bettingMatch, msg.sender, token, received, usdcReceived, marketId, selection);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -424,14 +440,14 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
         if (token == address(usdc)) revert TokenIsUSDC();
         if (block.timestamp > deadline) revert DeadlinePassed();
 
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-        uint256 usdcReceived = _swapTokensToUSDC(token, amount, amountOutMin, deadline);
+        uint256 received = _pullToken(IERC20(token), msg.sender, amount);
+        uint256 usdcReceived = _swapTokensToUSDC(token, received, amountOutMin, deadline);
         (uint256 fee, uint256 streamerAmt) = _splitAndTransfer(streamer, usdcReceived);
 
         // Record donation in StreamWallet
         _recordDonation(streamer, msg.sender, usdcReceived, fee, streamerAmt, message);
 
-        emit DonationWithToken(msg.sender, streamer, token, amount, usdcReceived, fee, message);
+        emit DonationWithToken(msg.sender, streamer, token, received, usdcReceived, fee, message);
     }
 
     /**
@@ -451,14 +467,14 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
         if (duration == 0) revert ZeroValue();
         if (block.timestamp > deadline) revert DeadlinePassed();
 
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-        uint256 usdcReceived = _swapTokensToUSDC(token, amount, amountOutMin, deadline);
+        uint256 received = _pullToken(IERC20(token), msg.sender, amount);
+        uint256 usdcReceived = _swapTokensToUSDC(token, received, amountOutMin, deadline);
         (uint256 fee,) = _splitAndTransfer(streamer, usdcReceived);
 
         // Record subscription in StreamWallet
         _recordSubscription(streamer, msg.sender, usdcReceived, duration);
 
-        emit SubscriptionWithToken(msg.sender, streamer, token, amount, usdcReceived, fee, duration);
+        emit SubscriptionWithToken(msg.sender, streamer, token, received, usdcReceived, fee, duration);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -467,21 +483,28 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
 
     function setTreasury(address _treasury) external onlyOwner {
         if (_treasury == address(0)) revert ZeroAddress();
+        address old = treasury;
         treasury = _treasury;
+        emit TreasurySet(old, _treasury);
     }
 
     function setPlatformFeeBps(uint16 _feeBps) external onlyOwner {
         if (_feeBps > 10_000) revert InvalidFeeBps();
+        uint16 old = platformFeeBps;
         platformFeeBps = _feeBps;
+        emit PlatformFeeBpsSet(old, _feeBps);
     }
 
     /// @notice Register the BettingMatchFactory so that bettingMatch addresses are validated
     ///         before USDC is forwarded to them (M-02 fix).
-    /// @dev Set this immediately after deployment. Once set, placeBetWith* functions will
-    ///      reject any bettingMatch that was not deployed by this factory.
+    /// @dev MUST be set before any `placeBetWith*` call. Validation is ALWAYS enforced
+    ///      in `_placeBetOnBehalf`; pre-registration means every bet reverts with
+    ///      `BettingMatchFactoryNotSet`. No silent-forward path exists.
     function setMatchFactory(address _factory) external onlyOwner {
         if (_factory == address(0)) revert ZeroAddress();
+        address old = address(bettingMatchFactory);
         bettingMatchFactory = BettingMatchFactory(_factory);
+        emit MatchFactorySet(old, _factory);
     }
 
     /// @notice Register the StreamWalletFactory for wallet recording.
@@ -497,12 +520,32 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
         if (StreamWalletFactory(_factory).swapRouter() != address(this)) {
             revert RouterNotConfiguredOnFactory();
         }
+        address old = address(streamWalletFactory);
         streamWalletFactory = StreamWalletFactory(_factory);
+        emit StreamWalletFactorySet(old, _factory);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
     // INTERNAL — SWAP HELPERS
     // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @dev Pull `declared` tokens from `from` to this contract and return the
+     *      *actual* amount received. Fee-on-transfer, rebasing, and other
+     *      non-conforming ERC20s deliver less than `declared`; we swap what we
+     *      actually hold, not what the user said they'd send.
+     */
+    function _pullToken(IERC20 token, address from, uint256 declared)
+        internal
+        returns (uint256 received)
+    {
+        uint256 balBefore = token.balanceOf(address(this));
+        token.safeTransferFrom(from, address(this), declared);
+        uint256 balAfter = token.balanceOf(address(this));
+        // Underflow-safe: balAfter >= balBefore or safeTransferFrom would have reverted.
+        received = balAfter - balBefore;
+        if (received == 0) revert ZeroValue();
+    }
 
     /**
      * @dev Swap exact native CHZ to USDC via Kayen master router
@@ -559,8 +602,10 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
 
     /**
      * @dev Transfer USDC to betting contract and place bet on behalf of user.
-     *      If bettingMatchFactory is configured, the target address is validated
-     *      against the factory registry before any funds are forwarded (M-02 fix).
+     *      Validation against the factory registry is ALWAYS enforced — USDC is
+     *      never forwarded to an address that the factory didn't deploy. If the
+     *      factory has not yet been registered, the call reverts (loud failure,
+     *      not silent fund loss).
      */
     function _placeBetOnBehalf(
         address bettingMatch,
@@ -569,13 +614,10 @@ contract ChilizSwapRouter is ReentrancyGuard, Ownable {
         uint256 amount
     ) internal {
         if (bettingMatch == address(0)) revert ZeroAddress();
-        // Validate against factory registry when available. This prevents USDC from
-        // being forwarded to arbitrary contracts that happen to implement placeBetUSDCFor.
-        if (address(bettingMatchFactory) != address(0)) {
-            if (!bettingMatchFactory.isMatch(bettingMatch)) {
-                revert UnauthorizedBettingMatch(bettingMatch);
-            }
-        }
+        BettingMatchFactory factory = bettingMatchFactory;
+        if (address(factory) == address(0)) revert BettingMatchFactoryNotSet();
+        if (!factory.isMatch(bettingMatch)) revert UnauthorizedBettingMatch(bettingMatch);
+
         usdc.safeTransfer(bettingMatch, amount);
         BettingMatch(payable(bettingMatch)).placeBetUSDCFor(msg.sender, marketId, selection, amount);
     }

--- a/chiliz-tv/test/BettingMatchFactoryTest.t.sol
+++ b/chiliz-tv/test/BettingMatchFactoryTest.t.sol
@@ -5,6 +5,10 @@ import {Test} from "forge-std/Test.sol";
 import {BettingMatchFactory} from "../src/betting/BettingMatchFactory.sol";
 import {FootballMatch} from "../src/betting/FootballMatch.sol";
 import {BasketballMatch} from "../src/betting/BasketballMatch.sol";
+import {LiquidityPool} from "../src/liquidity/LiquidityPool.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {MockUSDC} from "./mocks/MockUSDC.sol";
 
 /**
  * @title BettingMatchFactoryTest
@@ -24,8 +28,14 @@ import {BasketballMatch} from "../src/betting/BasketballMatch.sol";
  */
 contract BettingMatchFactoryTest is Test {
     BettingMatchFactory public factory;
+    LiquidityPool public pool;
+    MockUSDC public usdc;
 
+    address public poolAdmin = address(0x01);
+    address public poolTreasury = address(0x02);
+    address public swapRouter = address(0x03);
     address public matchOwner = address(0x10);
+    address public oracle     = address(0x20);
     address public nonOwner   = address(0x99);
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -34,6 +44,32 @@ contract BettingMatchFactoryTest is Test {
 
     function setUp() public {
         factory = new BettingMatchFactory();
+        usdc = new MockUSDC();
+
+        // Deploy a LiquidityPool proxy so matches have a valid wiring target.
+        LiquidityPool poolImpl = new LiquidityPool();
+        bytes memory poolInitData = abi.encodeWithSelector(
+            LiquidityPool.initialize.selector,
+            IERC20(address(usdc)),
+            poolAdmin,
+            poolTreasury,
+            uint16(0),     // protocolFeeBps
+            uint16(5000),  // maxMarketBps
+            uint16(9000),  // maxMatchBps
+            uint48(0)      // cooldown
+        );
+        ERC1967Proxy poolProxy = new ERC1967Proxy(address(poolImpl), poolInitData);
+        pool = LiquidityPool(address(poolProxy));
+
+        // Grant MATCH_AUTHORIZER_ROLE to factory so createXxxMatch can call
+        // pool.authorizeMatch atomically. Cache the role hash first — otherwise
+        // the view call consumes the prank.
+        bytes32 authRole = pool.MATCH_AUTHORIZER_ROLE();
+        vm.prank(poolAdmin);
+        pool.grantRole(authRole, address(factory));
+
+        // Configure factory wiring.
+        factory.setWiring(address(pool), address(usdc), swapRouter);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -104,7 +140,7 @@ contract BettingMatchFactoryTest is Test {
     // ══════════════════════════════════════════════════════════════════════════
 
     function test_CreateFootballMatch_Registered() public {
-        address proxy = factory.createFootballMatch("Test Match", matchOwner);
+        address proxy = factory.createFootballMatch("Test Match", matchOwner, oracle);
 
         assertTrue(factory.isMatch(proxy));
         assertEq(
@@ -116,7 +152,7 @@ contract BettingMatchFactoryTest is Test {
     }
 
     function test_CreateBasketballMatch_Registered() public {
-        address proxy = factory.createBasketballMatch("Test Match", matchOwner);
+        address proxy = factory.createBasketballMatch("Test Match", matchOwner, oracle);
 
         assertTrue(factory.isMatch(proxy));
         assertEq(
@@ -126,9 +162,9 @@ contract BettingMatchFactoryTest is Test {
     }
 
     function test_MultipleMatches_AllRegistered() public {
-        address fb1 = factory.createFootballMatch("FB1", matchOwner);
-        address fb2 = factory.createFootballMatch("FB2", matchOwner);
-        address bb1 = factory.createBasketballMatch("BB1", matchOwner);
+        address fb1 = factory.createFootballMatch("FB1", matchOwner, oracle);
+        address fb2 = factory.createFootballMatch("FB2", matchOwner, oracle);
+        address bb1 = factory.createBasketballMatch("BB1", matchOwner, oracle);
 
         assertEq(factory.getAllMatches().length, 3);
         assertTrue(factory.isMatch(fb1));
@@ -145,7 +181,7 @@ contract BettingMatchFactoryTest is Test {
         address newImpl = address(new FootballMatch());
         factory.setFootballImplementation(newImpl);
 
-        address proxy = factory.createFootballMatch("New Match", matchOwner);
+        address proxy = factory.createFootballMatch("New Match", matchOwner, oracle);
         assertTrue(factory.isMatch(proxy));
 
         // Verify the proxy's ERC1967 implementation slot points to newImpl
@@ -159,7 +195,7 @@ contract BettingMatchFactoryTest is Test {
     // ══════════════════════════════════════════════════════════════════════════
 
     function test_GetSportType_Football() public {
-        address proxy = factory.createFootballMatch("Match", matchOwner);
+        address proxy = factory.createFootballMatch("Match", matchOwner, oracle);
         assertEq(
             uint8(factory.getSportType(proxy)),
             uint8(BettingMatchFactory.SportType.FOOTBALL)
@@ -167,7 +203,7 @@ contract BettingMatchFactoryTest is Test {
     }
 
     function test_GetSportType_Basketball() public {
-        address proxy = factory.createBasketballMatch("Match", matchOwner);
+        address proxy = factory.createBasketballMatch("Match", matchOwner, oracle);
         assertEq(
             uint8(factory.getSportType(proxy)),
             uint8(BettingMatchFactory.SportType.BASKETBALL)

--- a/chiliz-tv/test/StreamBeaconRegistryTest.t.sol
+++ b/chiliz-tv/test/StreamBeaconRegistryTest.t.sol
@@ -741,8 +741,9 @@ contract StreamBeaconRegistryTest is Test {
         address walletAddr = factory.deployWalletFor(streamer1);
         StreamWallet wallet = StreamWallet(payable(walletAddr));
 
-        // streamer1 is the wallet owner — setting zero address must revert
-        vm.prank(streamer1);
+        // Only the factory can rotate the swap router (H-1). Factory passes a
+        // zero address → InvalidAddress.
+        vm.prank(address(factory));
         vm.expectRevert(StreamWallet.InvalidAddress.selector);
         wallet.setSwapRouter(address(0));
     }
@@ -757,19 +758,26 @@ contract StreamBeaconRegistryTest is Test {
         vm.expectEmit(true, true, false, false);
         emit StreamWallet.SwapRouterUpdated(address(0), newRouter);
 
-        vm.prank(streamer1);
+        // Factory-only after H-1 (previously streamer/owner could also call).
+        vm.prank(address(factory));
         wallet.setSwapRouter(newRouter);
 
         assertEq(wallet.swapRouter(), newRouter);
     }
 
-    function test_L03_SetSwapRouter_OnlyOwnerOrFactory() public {
+    function test_L03_SetSwapRouter_OnlyFactory() public {
         vm.prank(admin);
         address walletAddr = factory.deployWalletFor(streamer1);
         StreamWallet wallet = StreamWallet(payable(walletAddr));
 
-        // viewer1 is neither owner nor factory — must revert
+        // viewer1 is not the factory — must revert.
         vm.prank(viewer1);
+        vm.expectRevert(StreamWallet.OnlyAuthorized.selector);
+        wallet.setSwapRouter(address(0x1));
+
+        // H-1 regression: the streamer (wallet owner) must NOT be able to swap
+        // the router — that was the vector for fabricating revenue events.
+        vm.prank(streamer1);
         vm.expectRevert(StreamWallet.OnlyAuthorized.selector);
         wallet.setSwapRouter(address(0x1));
     }

--- a/chiliz-tv/test/SwapIntegrationTest.t.sol
+++ b/chiliz-tv/test/SwapIntegrationTest.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.22;
 import {Test, console} from "forge-std/Test.sol";
 import {BettingMatch} from "../src/betting/BettingMatch.sol";
 import {FootballMatch} from "../src/betting/FootballMatch.sol";
+import {BettingMatchFactory} from "../src/betting/BettingMatchFactory.sol";
 import {ChilizSwapRouter} from "../src/swap/ChilizSwapRouter.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -37,6 +38,7 @@ contract SwapIntegrationTest is Test {
     MockFanTokenSwap public fanToken;
     ChilizSwapRouter public swapRouter;
     LiquidityPool public pool;
+    BettingMatchFactory public factory;
 
     address public owner = address(0x1);
     address public oddsSetter = address(0x2);
@@ -65,22 +67,15 @@ contract SwapIntegrationTest is Test {
         mockRouter = new MockKayenRouter(address(usdc));
         fanToken = new MockFanTokenSwap();
 
-        // Deploy betting implementation + proxy
-        implementation = new FootballMatch();
-        bytes memory initData = abi.encodeWithSelector(
-            FootballMatch.initialize.selector,
-            "Barcelona vs Real Madrid",
-            owner
+        // Deploy LiquidityPool first so the factory can wire matches to it.
+        LiquidityPool poolImpl = new LiquidityPool();
+        bytes memory poolInitData = abi.encodeWithSelector(
+            LiquidityPool.initialize.selector,
+            address(usdc), owner, owner,
+            uint16(0), uint16(5000), uint16(9000), uint48(0)
         );
-        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
-        footballMatch = FootballMatch(payable(address(proxy)));
-
-        // Setup roles
-        vm.startPrank(owner);
-        footballMatch.grantRole(ODDS_SETTER_ROLE, oddsSetter);
-        footballMatch.grantRole(RESOLVER_ROLE, resolver);
-        footballMatch.setUSDCToken(address(usdc));
-        vm.stopPrank();
+        ERC1967Proxy poolProxy = new ERC1967Proxy(address(poolImpl), poolInitData);
+        pool = LiquidityPool(address(poolProxy));
 
         // Deploy swap router (unified: betting + streaming)
         swapRouter = new ChilizSwapRouter(
@@ -92,9 +87,35 @@ contract SwapIntegrationTest is Test {
             500              // 5% platform fee
         );
 
-        // Grant SWAP_ROUTER_ROLE to swapRouter
+        // Deploy factory and grant it MATCH_AUTHORIZER_ROLE on the pool so it can
+        // atomically register new matches on `createFootballMatch`.
+        factory = new BettingMatchFactory();
+        bytes32 authRole = pool.MATCH_AUTHORIZER_ROLE();
         vm.prank(owner);
-        footballMatch.grantRole(SWAP_ROUTER_ROLE, address(swapRouter));
+        pool.grantRole(authRole, address(factory));
+
+        // Wire the factory: new matches get USDC + pool + swapRouter set, and
+        // SWAP_ROUTER_ROLE granted to the swap router, all in one tx.
+        factory.setWiring(address(pool), address(usdc), address(swapRouter));
+
+        // Register the factory on the swap router so `placeBetWith*` validates
+        // every `bettingMatch` argument against the factory's registry.
+        swapRouter.setMatchFactory(address(factory));
+
+        // Create the match through the factory (atomic wiring). `resolver` gets
+        // RESOLVER_ROLE; `owner` becomes match admin. Implementation is read
+        // back from the factory for the ERC1967-slot assertion (if any).
+        address matchAddr = factory.createFootballMatch(
+            "Barcelona vs Real Madrid",
+            owner,
+            resolver
+        );
+        footballMatch = FootballMatch(payable(matchAddr));
+        implementation = FootballMatch(payable(factory.footballImplementation()));
+
+        // Additional role grant: legacy oddsSetter wiring.
+        vm.prank(owner);
+        footballMatch.grantRole(ODDS_SETTER_ROLE, oddsSetter);
 
         // Fund accounts
         vm.deal(alice, 100 ether);
@@ -109,21 +130,6 @@ contract SwapIntegrationTest is Test {
         // Mint fan tokens for ERC20 swap tests
         fanToken.mint(alice, 1000 ether);
         fanToken.mint(bob, 1000 ether);
-
-        // Deploy and wire LiquidityPool
-        LiquidityPool poolImpl = new LiquidityPool();
-        bytes memory poolInitData = abi.encodeWithSelector(
-            LiquidityPool.initialize.selector,
-            address(usdc), owner, owner,
-            uint16(0), uint16(5000), uint16(9000), uint48(0)
-        );
-        ERC1967Proxy poolProxy = new ERC1967Proxy(address(poolImpl), poolInitData);
-        pool = LiquidityPool(address(poolProxy));
-
-        vm.startPrank(owner);
-        footballMatch.setLiquidityPool(address(pool));
-        pool.authorizeMatch(address(footballMatch));
-        vm.stopPrank();
 
         // Fund LiquidityPool with USDC for payouts
         usdc.mint(address(pool), 10000e6);


### PR DESCRIPTION
…ening

Addresses C-1, C-2/H-2, H-1, H-3, H-4 from the security audit.

C-1 (swap-router validation):
  - ChilizSwapRouter._placeBetOnBehalf now ALWAYS validates `bettingMatch` against the registered factory; reverts with new error `BettingMatchFactoryNotSet` if the factory is unset (no silent USDC forward to arbitrary contracts).
  - DeployAll._linkContracts wires `swapRouter.setMatchFactory(factory)`.

C-2 / H-2 (admin-setter visibility):
  - Added events `TreasurySet`, `PlatformFeeBpsSet`, `MatchFactorySet`, `StreamWalletFactorySet` on ChilizSwapRouter.

H-1 (StreamWallet privilege):
  - `setSwapRouter` is now factory-only. Streamers (owner) can no longer rotate the router and fabricate revenue events.

H-3 (fee-on-transfer hardening):
  - New `_pullToken` helper measures actual delivered balance around `safeTransferFrom`. Used by `placeBetWithToken`, `donateWithToken`, `subscribeWithToken` so non-conforming ERC-20s can't desync the swapped amount.

H-4 (atomic match wiring):
  - LiquidityPool: new narrow `MATCH_AUTHORIZER_ROLE`; `authorizeMatch` / `revokeMatch` accept either it or DEFAULT_ADMIN_ROLE.
  - BettingMatchFactory: new wiring config (`liquidityPool`, `usdcToken`, `swapRouter`) + `setWiring`. `createFootballMatch` / `createBasketballMatch` now take an `_oracle` param and atomically init the proxy, set USDC + pool, grant SWAP_ROUTER_ROLE + RESOLVER_ROLE, hand admin to the match owner, transfer Ownable, call `pool.authorizeMatch`, and renounce every factory-held role.
  - ILiquidityPool: added `authorizeMatch` / `revokeMatch`.
  - Back-compat: factory exposes `FOOTBALL` / `BASKETBALL` uint8 constants and an `implementations(uint8)` getter so legacy scripts compile.

Tests: 153 / 153 passing. Coverage 83% lines / 41% branches.